### PR TITLE
Fix GPU memory leak in batch_training / Model.fit

### DIFF
--- a/m3_learning/src/m3_learning/be/nn.py
+++ b/m3_learning/src/m3_learning/be/nn.py
@@ -707,9 +707,10 @@ def batch_training(dataset, optimizers, noise_list, batch_size, epochs, seed, wr
 
         del model, X_train, X_test, y_train, y_test
 
-        torch.cuda.empty_cache()
-        clear_all_tensors()
+        # Collect first so the (now cycle-free) graph tensors are dropped, THEN return the freed
+        # memory to the device. Calling empty_cache() before gc.collect() leaves it stranded.
         gc.collect()
+        torch.cuda.empty_cache()
 
 
 def clear_all_tensors():

--- a/m3_learning/src/m3_learning/nn/Fitter1D/Fitter1D.py
+++ b/m3_learning/src/m3_learning/nn/Fitter1D/Fitter1D.py
@@ -492,6 +492,15 @@ class Model(nn.Module):
 
         self.model.eval()
 
+        # Release the autograd graph retained by backward(create_graph=True) (which the
+        # second-order optimizers require). Setting .grad=None breaks the parameter<->gradient
+        # reference cycle so the graph's GPU tensors are freed once this model is deleted.
+        # Without this, every batch_training run strands ~0.15 GB on the GPU and the 360-run
+        # loop OOMs. The state_dict is already saved above, so this changes no saved weights,
+        # losses, or training behavior -- it is purely memory cleanup after training completes.
+        for param in self.model.parameters():
+            param.grad = None
+
     def load(self, model_path):
         self.model.load_state_dict(torch.load(model_path))
         self.model.to(self.device)


### PR DESCRIPTION
## Problem
`Model.fit` calls `loss.backward(create_graph=True)` (required by the second-order optimizers AdaHessian / Trust-Region CG). `create_graph=True` creates a reference cycle between each parameter and its `.grad`, keeping the autograd graph (batch activations) alive. The gradients are never reset, so every trained model strands its graph on the GPU.

In `2_5_nn_fitting_all`'s 360-run benchmark this accumulates ~0.15 GB/run and exhausts a 23 GB GPU around run ~116 with `torch.cuda.OutOfMemoryError`. (PyTorch even warns about this exact cycle.)

## Fix (pure memory cleanup — training is numerically identical)
- **`Fitter1D.Model.fit`**: after each `fit()` finishes (state_dict already saved), set `param.grad = None` for all params, breaking the param↔grad cycle so the graph frees when the model is deleted. `create_graph=True` is left untouched, so AdaHessian/TRCG behave exactly as before.
- **`be.nn.batch_training`**: run `gc.collect()` *before* `torch.cuda.empty_cache()` so reclaimed memory is returned to the device; removed the no-op `clear_all_tensors()` call (its `dir()` ran in the function's own scope and cleared nothing).

## Validation
- Micro-test: GPU `memory_allocated` flat across runs (was +150 MB/run).
- Full scale: the entire 360-run benchmark plus notebooks 3/5/6 completed on a 23 GB A10 with VRAM bounded to ~0.5–2.9 GB throughout (previously OOM'd at run ~116).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix GPU memory leaks during model training by properly releasing autograd graphs and synchronizing Python garbage collection with CUDA cache clearing.

Bug Fixes:
- Clear parameter gradients after Model.fit completes to break autograd reference cycles and free GPU memory.
- Run Python garbage collection before torch.cuda.empty_cache() in batch_training and remove the ineffective tensor-clearing call to ensure freed tensors are actually returned to the GPU.