### PR TITLE
Publication-quality violin plots + regeneration script

### DIFF
--- a/m3_learning/papers/2023_Rapid_Fitting/regenerate_violins.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/regenerate_violins.py
@@ -1,0 +1,94 @@
+"""Regenerate the publication-clean SHO violin (Figure_16_Violin) from cached data.
+
+Run this on a machine that has the experiment h5 (with the cached LSQF SHO fit)
+and the trained Adam checkpoint -- e.g. the Lambda box / persistent NFS that ran
+the full pipeline. It loads the saved weights (no retraining), runs inference,
+and renders the violin with the fixed publication styling in be/viz.py.
+
+Usage (from papers/2023_Rapid_Fitting/, with the SDK installed):
+    python regenerate_violins.py [--data PATH_TO_h5] [--ckpt PATH_TO_pth]
+
+Defaults assume the standard layout: ./Data/data_raw.h5 and the Adam checkpoint
+under ./Trained Models/SHO Fitter/. Output: ./Figures/Figure_16_Violin.png/.svg
+"""
+import argparse
+import glob
+import numpy as np
+
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.viz.printing import printer
+from m3_learning.be.viz import Viz
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn
+from m3_learning.nn.Fitter1D.Fitter1D import (
+    Multiscale1DFitter,
+    Model,
+    ComplexPostProcessor,
+)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data", default="./Data/data_raw.h5",
+                    help="path to the experiment h5 with the cached LSQF SHO fit")
+    ap.add_argument("--ckpt", default=None,
+                    help="path to the trained Adam .pth checkpoint "
+                         "(default: auto-find under ./Trained Models/SHO Fitter/)")
+    args = ap.parse_args()
+
+    set_style("printing")
+    random_seed(seed=42)
+
+    printing = printer(basepath="./Figures/")
+
+    # dataset + cached LSQF fit (SHO_Fitter is idempotent -- instant if already fit)
+    dataset = BE_Dataset(args.data, SHO_fit_func_LSQF=SHO_fit_func_nn)
+    dataset.SHO_Fitter(force=False, h5_sho_targ_grp="Raw_Data_SHO_Fit")
+    dataset = BE_Dataset(args.data, SHO_fit_func_LSQF=SHO_fit_func_nn)
+
+    BE_viz = Viz(
+        dataset, printing, verbose=True,
+        SHO_ranges=[(0, 1.5e-4), (1.31e6, 1.33e6), (-300, 0), (-np.pi, np.pi)],
+        image_scalebar=[2000, 500, "nm", "br"],
+    )
+
+    # rebuild the network and LOAD the trained Adam weights (no retraining)
+    postprocessor = ComplexPostProcessor(dataset)
+    model_ = Multiscale1DFitter(
+        SHO_fit_func_nn, dataset.frequency_bin, 2, 4,
+        dataset.SHO_scaler, postprocessor,
+    )
+    model = Model(model_, dataset, training=True,
+                  model_basename="SHO_Fitter_original_data")
+
+    ckpt = args.ckpt
+    if ckpt is None:
+        hits = sorted(glob.glob(
+            "Trained Models/SHO Fitter/"
+            "SHO_Fitter_original_data_model_optimizer_Adam_epoch_4*.pth"))
+        if not hits:
+            raise SystemExit(
+                "No Adam checkpoint found under 'Trained Models/SHO Fitter/'. "
+                "Pass one with --ckpt.")
+        ckpt = hits[0]
+    print(f"Loading checkpoint: {ckpt}")
+    model.load(ckpt)
+
+    X_data, _ = dataset.NN_data()
+
+    true_state = {
+        "fitter": "LSQF",
+        "raw_format": "complex",
+        "resampled": True,
+        "scaled": True,
+        "output_shape": "index",
+        "measurement_state": "all",
+    }
+    BE_viz.violin_plot_comparison(true_state, model, X_data,
+                                  filename="Figure_16_Violin")
+    print("Wrote ./Figures/Figure_16_Violin.png and .svg")
+
+
+if __name__ == "__main__":
+    main()

--- a/m3_learning/src/m3_learning/be/viz.py
+++ b/m3_learning/src/m3_learning/be/viz.py
@@ -2053,24 +2053,34 @@ class Viz:
 
                 df = pd.concat((df, pd.DataFrame(dict_)), ignore_index=True)
 
-        # builds the plot
-        fig, ax = plt.subplots(figsize=(2, 2))
+        # builds the plot at a publication-legible size
+        fig, ax = plt.subplots(figsize=(6, 3.6))
 
-        # plots the data
-        sns.violinplot(
-            data=df, x="parameter", y="value", hue="dataset", split=True, ax=ax
-        )
+        # Split violins (LSQF | NN) per parameter. density_norm="width" makes
+        # every violin the same maximum width so the heavy-tailed Q/phi
+        # parameters do not compress the others into slivers; inner="quart"
+        # draws thin quartile lines instead of the default heavy inner box;
+        # cut=0 stops the kernel density from extending past the data.
+        try:
+            sns.violinplot(
+                data=df, x="parameter", y="value", hue="dataset", split=True,
+                inner="quart", cut=0, density_norm="width", linewidth=0.8,
+                palette={"LSQF": "#3B75AF", "NN": "#EF8636"}, ax=ax,
+            )
+        except TypeError:
+            # older seaborn (<0.13) uses scale= instead of density_norm=
+            sns.violinplot(
+                data=df, x="parameter", y="value", hue="dataset", split=True,
+                inner="quartile", cut=0, scale="width", linewidth=0.8,
+                palette={"LSQF": "#3B75AF", "NN": "#EF8636"}, ax=ax,
+            )
 
-        # labels the figure and does some styling
-        labelfigs(ax, 0, style="b")
-        ax.set_ylabel("Scaled SHO Results")
+        ax.set_ylabel("Scaled SHO parameter")
         ax.set_xlabel("")
-
-        # Get the legend associated with the plot
-        legend = ax.get_legend()
-        legend.set_title("")
-
-        # ax.set_aspect(1)
+        ax.axhline(0, color="0.6", lw=0.5, zorder=0)
+        ax.legend(title="", frameon=False, loc="upper right")
+        sns.despine(ax=ax)
+        fig.tight_layout()
 
         # prints the figure
         if self.Printer is not None and filename is not None:
@@ -2109,21 +2119,28 @@ class Viz:
 
                 df = pd.concat((df, pd.DataFrame(dict_)), ignore_index=True)
 
-        # builds the plot
-        fig, ax = plt.subplots(figsize=(4, 4))
+        # builds the plot at a publication-legible size (9 loop parameters)
+        fig, ax = plt.subplots(figsize=(8, 3.6))
 
-        sns.violinplot(
-            data=df, x="parameter", y="value", hue="dataset", split=True, ax=ax, linewidth=.1,
-        )
+        try:
+            sns.violinplot(
+                data=df, x="parameter", y="value", hue="dataset", split=True,
+                inner="quart", cut=0, density_norm="width", linewidth=0.7,
+                palette={"LSQF": "#3B75AF", "NN": "#EF8636"}, ax=ax,
+            )
+        except TypeError:
+            sns.violinplot(
+                data=df, x="parameter", y="value", hue="dataset", split=True,
+                inner="quartile", cut=0, scale="width", linewidth=0.7,
+                palette={"LSQF": "#3B75AF", "NN": "#EF8636"}, ax=ax,
+            )
 
-        # labels the figure and does some styling
-        labelfigs(ax, 0, style="b")
-        ax.set_ylabel("Scaled SHO Results")
+        ax.set_ylabel("Scaled loop parameter")
         ax.set_xlabel("")
-
-        # Get the legend associated with the plot
-        legend = ax.get_legend()
-        legend.set_title("")
+        ax.axhline(0, color="0.6", lw=0.5, zorder=0)
+        ax.legend(title="", frameon=False, loc="upper right")
+        sns.despine(ax=ax)
+        fig.tight_layout()
 
         # prints the figure
         if self.Printer is not None and filename is not None:

--- a/m3_learning/src/m3_learning/be/viz.py
+++ b/m3_learning/src/m3_learning/be/viz.py
@@ -1283,12 +1283,15 @@ class Viz:
                         ax_.set_ylabel("Real (Arb. U.)")
                         ax1.set_ylabel("Imag (Arb. U.)")
 
-                if i < num_fits:
-                    # add a legend just for the last one
+                if i == 0:
+                    # ONE shared legend above the panel grid instead of crowding
+                    # every small panel with the full LSQF/Raw/NN x amplitude/phase
+                    # key (which previously overlapped the data in each panel).
                     lines, labels = ax_.get_legend_handles_labels()
                     lines2, labels2 = ax1.get_legend_handles_labels()
-                    ax_.legend(lines + lines2, labels +
-                               labels2, loc="upper right")
+                    fig.legend(lines + lines2, labels + labels2,
+                               loc="upper center", bbox_to_anchor=(0.5, 1.04),
+                               ncol=3, frameon=False, fontsize="small")
 
         # prints the figure
         if self.Printer is not None and filename is not None:
@@ -2902,11 +2905,12 @@ class Viz:
                 ax[plot_idx - 1].set_ylabel("(Arb. U.)")
                 ax[plot_idx].set_ylabel("(Arb. U.)")
 
-        # add a legend just for the last one
-        lines, labels = ax[plot_idx - 1].get_legend_handles_labels()
-        ax[plot_idx - 1].legend(lines, labels, loc="upper right")
+        # ONE shared legend above the panel grid instead of putting a legend in
+        # the last panels, where it overlapped the measured-loop points.
         lines, labels = ax[plot_idx].get_legend_handles_labels()
-        ax[plot_idx].legend(lines, labels, loc="upper right")
+        fig.legend(lines, labels, loc="upper center",
+                   bbox_to_anchor=(0.5, 1.02), ncol=3, frameon=False,
+                   fontsize="small")
 
         ax[plot_idx - 1].set_xlabel("Voltage (V)")
         ax[plot_idx].set_xlabel("Voltage (V)")


### PR DESCRIPTION
Fixes the unreadable SHO/hysteresis violin comparison plots (`be/viz.py`): legible figure size, width-normalized split violins (heavy-tailed Q/φ no longer compress the others), thin quartile inner lines instead of the default heavy box, clean LSQF/NN palette, despined axes, and removal of the `labelfigs()` call that injected a stray panel-label glyph. Adds `papers/2023_Rapid_Fitting/regenerate_violins.py` to re-render the violin from a cached h5 + the trained Adam checkpoint (no retraining).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve SHO and hysteresis violin comparison plots for publication-quality output and add a script to regenerate the published violin figure from cached data and a trained checkpoint.

New Features:
- Add a reproducible script to regenerate the publication SHO violin figure from cached experiment data and a saved Adam checkpoint without retraining.

Enhancements:
- Refine SHO parameter violin plots with publication-legible sizing, width-normalized split violins, lighter quartile-based interiors, consistent LSQF/NN color palette, axis despining, and cleaner legends.
- Refine hysteresis loop parameter violin plots with analogous publication-focused sizing and styling, including width-normalized split violins and simplified axes and legends.