### PR TITLE
Figure readability: titled fit panels + rebuilt switching-map grids

### DIFF
--- a/m3_learning/papers/2023_Rapid_Fitting/analysis_p1_p4.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/analysis_p1_p4.py
@@ -1,0 +1,197 @@
+"""Priorities 1-4: SHO parameter agreement, reconstruction-MSE distribution + paired
+test, unphysical-outlier counts, and train/test overfitting check.
+
+Loads the cached LSQF SHO fit + the Adam epoch-4 checkpoint (NO retraining), runs
+inference over all spectra, and prints copy-paste numeric summaries. Figures saved
+to ./Figures/ as PNG (300 dpi) + SVG. Colors: LSQF #3B75AF, NN #EF8636.
+"""
+import argparse
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from scipy import stats
+from sklearn.metrics import r2_score
+
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn, SHO_Model
+from m3_learning.nn.Fitter1D.Fitter1D import Multiscale1DFitter, Model, ComplexPostProcessor
+
+LSQF_C, NN_C = "#0072B2", "#E69F00"
+LABELS = ["A", "omega_0", "Q", "phi"]
+SHO_RANGES = [(0, 1.5e-4), (1.31e6, 1.33e6), (-300, 0), (-np.pi, np.pi)]
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--data", required=True)
+ap.add_argument("--ckpt", required=True)
+args = ap.parse_args()
+
+set_style("printing")
+import sys as _s, os as _o
+_s.path.insert(0, _o.path.dirname(_o.path.abspath(__file__)))
+from pubstyle import set_pub_style, METHOD_COLORS, SEQ_CMAP
+set_pub_style()
+random_seed(seed=42)
+
+dataset = BE_Dataset(args.data, SHO_fit_func_LSQF=SHO_fit_func_nn)
+dataset.SHO_Fitter(force=False, h5_sho_targ_grp="Raw_Data_SHO_Fit")
+dataset = BE_Dataset(args.data, SHO_fit_func_LSQF=SHO_fit_func_nn)
+
+# state matching the paper violin
+state = {"fitter": "LSQF", "raw_format": "complex", "resampled": True,
+         "scaled": True, "output_shape": "index", "measurement_state": "all"}
+dataset.set_attributes(**state)
+
+# build + load model (no retraining)
+post = ComplexPostProcessor(dataset)
+model_ = Multiscale1DFitter(SHO_fit_func_nn, dataset.frequency_bin, 2, 4,
+                            dataset.SHO_scaler, post)
+model = Model(model_, dataset, training=True, model_basename="SHO_Fitter_original_data")
+print(f"Loading checkpoint: {args.ckpt}")
+model.load(args.ckpt)
+
+X_data, _ = dataset.NN_data()
+n = X_data.shape[0]
+print(f"\nn spectra = {n}")
+
+# ---- params ----
+dataset.set_attributes(**state)
+pred_data, _, nn_phys = model.predict(X_data)           # physical NN params
+nn_phys = np.asarray(nn_phys)
+dataset.scaled = False
+lsqf_phys = dataset.SHO_fit_results().reshape(-1, 4)    # physical LSQF params
+dataset.scaled = True
+nn_scaled = dataset.SHO_scaler.transform(nn_phys)
+lsqf_scaled = dataset.SHO_fit_results().reshape(-1, 4)  # scaled LSQF (violin 'true')
+
+# =====================================================================
+# PRIORITY 1a — parameter-space agreement (scaled space; corr/R2 are scale-free)
+# =====================================================================
+print("\n" + "=" * 78)
+print("PRIORITY 1a  NN-vs-LSQF SHO parameter agreement  (n = %d, all spectra)" % n)
+print("=" * 78)
+hdr = f"{'param':>8} | {'medianAbsDiff':>13} {'IQR(diff)':>10} | {'Pearson':>8} {'Spearman':>9} {'R^2':>8}  (scaled)"
+print(hdr); print("-" * len(hdr))
+p1 = {}
+for i, lab in enumerate(LABELS):
+    a, b = lsqf_scaled[:, i], nn_scaled[:, i]
+    diff = b - a
+    mad = np.median(np.abs(diff))
+    iqr = np.percentile(diff, 75) - np.percentile(diff, 25)
+    pear = stats.pearsonr(a, b)[0]
+    spear = stats.spearmanr(a, b)[0]
+    r2 = r2_score(a, b)
+    # physical-units median |diff| for context
+    mad_phys = np.median(np.abs(nn_phys[:, i] - lsqf_phys[:, i]))
+    p1[lab] = dict(mad=mad, iqr=iqr, pearson=pear, spearman=spear, r2=r2, mad_phys=mad_phys)
+    print(f"{lab:>8} | {mad:13.4f} {iqr:10.4f} | {pear:8.4f} {spear:9.4f} {r2:8.4f}   (phys medianAbsDiff={mad_phys:.4g})")
+
+# ---- P1b: 4-panel hexbin NN vs LSQF (physical) ----
+fig, axes = plt.subplots(1, 4, figsize=(16, 4))
+for i, (ax, lab) in enumerate(zip(axes, LABELS)):
+    x, y = lsqf_phys[:, i], nn_phys[:, i]
+    hb = ax.hexbin(x, y, gridsize=80, bins="log", cmap=SEQ_CMAP, mincnt=1)
+    lo, hi = np.percentile(np.concatenate([x, y]), [0.1, 99.9])
+    ax.plot([lo, hi], [lo, hi], "r--", lw=1.2, label="y = x")
+    ax.set_xlim(lo, hi); ax.set_ylim(lo, hi)
+    ax.set_xlabel(f"LSQF  {lab}"); ax.set_ylabel(f"NN  {lab}")
+    ax.set_title(f"{lab}   (Pearson r={p1[lab]['pearson']:.3f}, R²={p1[lab]['r2']:.3f})", fontsize=9)
+    ax.legend(loc="upper left", fontsize=8, frameon=False)
+    fig.colorbar(hb, ax=ax, shrink=0.8, label="log10(count)")
+fig.tight_layout()
+fig.savefig("./Figures/Figure_param_agreement_scatter.png", dpi=300, bbox_inches="tight")
+fig.savefig("./Figures/Figure_param_agreement_scatter.svg", bbox_inches="tight")
+plt.close(fig)
+print("\nWrote ./Figures/Figure_param_agreement_scatter.png and .svg")
+
+# =====================================================================
+# PRIORITY 2 — per-spectrum reconstruction MSE + Wilcoxon paired test
+# =====================================================================
+def to_arr(lst):
+    return np.rollaxis(np.array(lst), 0, 3)  # [N, freq, 2]
+
+dataset.set_attributes(**state)
+dataset.scaled = True
+true_list, _ = dataset.raw_spectra(frequency=True)
+nn_recon, _ = dataset.raw_spectra(fit_results=nn_phys, frequency=True)
+lsqf_recon, _ = dataset.raw_spectra(fit_results=lsqf_phys, frequency=True)
+
+t = to_arr(true_list)
+mse_nn = Model.MSE(t, to_arr(nn_recon))
+mse_lsqf = Model.MSE(t, to_arr(lsqf_recon))
+
+def q(x):
+    return np.mean(x), np.median(x), np.percentile(x, 25), np.percentile(x, 75)
+
+print("\n" + "=" * 78)
+print("PRIORITY 2a  Per-spectrum reconstruction MSE  (scaled real/imag space)")
+print("=" * 78)
+for name, m in [("LSQF", mse_lsqf), ("NN  ", mse_nn)]:
+    mean, med, q1, q3 = q(m)
+    print(f"  {name}: mean={mean:.5f}  median={med:.5f}  Q1={q1:.5f}  Q3={q3:.5f}")
+W, p = stats.wilcoxon(mse_nn, mse_lsqf)               # paired, NN vs LSQF
+med_paired = np.median(mse_nn - mse_lsqf)
+frac_nn_better = np.mean(mse_nn < mse_lsqf)
+print(f"\n  Wilcoxon signed-rank (NN vs LSQF): W={W:.4g}  p={p:.3e}")
+print(f"  median paired diff (NN - LSQF) = {med_paired:+.6f}")
+print(f"  fraction of spectra where NN beats LSQF = {frac_nn_better:.4f}")
+verdict = ("BETTER (lower MSE)" if med_paired < 0 else "WORSE (higher MSE)") + \
+          (" and the difference is statistically significant" if p < 0.05 else
+           " but the difference is NOT statistically significant")
+print(f"  -> The network is {verdict}.")
+
+# ---- P2b: CDF + histogram ----
+fig, (axc, axh) = plt.subplots(1, 2, figsize=(12, 4.2))
+for m, c, lab in [(mse_lsqf, LSQF_C, "LSQF"), (mse_nn, NN_C, "NN")]:
+    xs = np.sort(m); ys = np.arange(1, len(xs) + 1) / len(xs)
+    axc.plot(xs, ys, color=c, lw=1.5, label=lab)
+axc.set_xlabel("per-spectrum reconstruction MSE"); axc.set_ylabel("CDF")
+axc.set_xlim(0, np.percentile(np.concatenate([mse_nn, mse_lsqf]), 99))
+axc.legend(frameon=False); axc.set_title("CDF")
+hi = np.percentile(np.concatenate([mse_nn, mse_lsqf]), 99)
+bins = np.linspace(0, hi, 120)
+axh.hist(mse_lsqf, bins=bins, color=LSQF_C, alpha=0.55, label="LSQF")
+axh.hist(mse_nn, bins=bins, color=NN_C, alpha=0.55, label="NN")
+axh.set_xlabel("per-spectrum reconstruction MSE"); axh.set_ylabel("count")
+axh.legend(frameon=False); axh.set_title("Histogram")
+fig.tight_layout()
+fig.savefig("./Figures/Figure_mse_distribution.png", dpi=300, bbox_inches="tight")
+fig.savefig("./Figures/Figure_mse_distribution.svg", bbox_inches="tight")
+plt.close(fig)
+print("Wrote ./Figures/Figure_mse_distribution.png and .svg")
+
+# =====================================================================
+# PRIORITY 3 — unphysical-outlier counts (physical params vs SHO_ranges)
+# =====================================================================
+print("\n" + "=" * 78)
+print("PRIORITY 3  Out-of-physical-range counts  (criterion: value strictly outside")
+print("            the codebase SHO_ranges; Q range is (-300,0) per the code's sign)")
+print("=" * 78)
+print(f"  ranges: A{SHO_RANGES[0]}  omega_0{SHO_RANGES[1]}  Q{SHO_RANGES[2]}  phi{SHO_RANGES[3]}")
+print(f"  {'param':>8} | {'LSQF n_out':>11} {'LSQF %':>8} | {'NN n_out':>9} {'NN %':>8}")
+print("  " + "-" * 52)
+for i, lab in enumerate(LABELS):
+    lo, hi = SHO_RANGES[i]
+    l_out = int(np.sum((lsqf_phys[:, i] < lo) | (lsqf_phys[:, i] > hi)))
+    n_out = int(np.sum((nn_phys[:, i] < lo) | (nn_phys[:, i] > hi)))
+    print(f"  {lab:>8} | {l_out:11d} {100*l_out/n:8.3f} | {n_out:9d} {100*n_out/n:8.3f}")
+
+# =====================================================================
+# PRIORITY 4 — overfitting check (train vs test reconstruction MSE)
+# =====================================================================
+print("\n" + "=" * 78)
+print("PRIORITY 4  Overfitting check (80/20 split, seed=42)")
+print("=" * 78)
+dataset.set_attributes(**state)
+Xtr, Xte, _, _ = dataset.test_train_split_(test_size=0.2, random_state=42)
+ptr, _, _ = model.predict(Xtr)
+pte, _, _ = model.predict(Xte)
+tr_mse = float(np.mean(Model.MSE(np.asarray(Xtr), np.asarray(ptr))))
+te_mse = float(np.mean(Model.MSE(np.asarray(Xte), np.asarray(pte))))
+print(f"  train MSE = {tr_mse:.6f}   (n={Xtr.shape[0]})")
+print(f"  test  MSE = {te_mse:.6f}   (n={Xte.shape[0]})")
+print(f"  test/train ratio = {te_mse/tr_mse:.4f}  -> "
+      f"{'no meaningful overfitting' if te_mse/tr_mse < 1.05 else 'some gap, inspect'}")
+print("\nDONE P1-P4")

--- a/m3_learning/papers/2023_Rapid_Fitting/analysis_p5.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/analysis_p5.py
@@ -1,0 +1,80 @@
+"""Priority 5: accuracy/robustness vs noise factor (n=0..8).
+
+For each noise level compute median per-spectrum reconstruction MSE for LSQF and the
+network, plus the spread (std) of the scaled SHO parameters. Plot metric vs noise.
+Also re-reports phi agreement with circular (wrapped) handling for the manuscript.
+"""
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn
+from m3_learning.nn.Fitter1D.Fitter1D import Multiscale1DFitter, Model, ComplexPostProcessor
+
+LSQF_C, NN_C = "#3B75AF", "#EF8636"
+DATA = "Data/data_raw.h5"
+CKPT = ("Trained Models/SHO Fitter/"
+        "SHO_Fitter_original_data_model_optimizer_Adam_epoch_4_train_loss_0.03403592322973526.pth")
+
+set_style("printing"); random_seed(seed=42)
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+post = ComplexPostProcessor(dataset)
+model_ = Multiscale1DFitter(SHO_fit_func_nn, dataset.frequency_bin, 2, 4, dataset.SHO_scaler, post)
+model = Model(model_, dataset, training=True, model_basename="SHO_Fitter_original_data")
+model.load(CKPT)
+
+def to_arr(lst):
+    return np.rollaxis(np.array(lst), 0, 3)
+
+base = {"fitter": "LSQF", "raw_format": "complex", "resampled": True,
+        "scaled": True, "output_shape": "index", "measurement_state": "all"}
+
+rows = []
+for k in range(9):
+    st = dict(base); st["noise"] = k
+    dataset.set_attributes(**st)
+    X, _ = dataset.NN_data()
+    _, _, nn_phys = model.predict(X)
+    nn_phys = np.asarray(nn_phys)
+    dataset.set_attributes(**st); dataset.scaled = False
+    lsqf_phys = dataset.SHO_fit_results().reshape(-1, 4)
+    dataset.scaled = True
+    true_list, _ = dataset.raw_spectra(frequency=True)
+    nn_recon, _ = dataset.raw_spectra(fit_results=nn_phys, frequency=True)
+    lsqf_recon, _ = dataset.raw_spectra(fit_results=lsqf_phys, frequency=True)
+    t = to_arr(true_list)
+    mse_nn = float(np.median(Model.MSE(t, to_arr(nn_recon))))
+    mse_lsqf = float(np.median(Model.MSE(t, to_arr(lsqf_recon))))
+    # param spread: mean over the 4 params of the scaled-param std
+    nn_scaled = dataset.SHO_scaler.transform(nn_phys)
+    lsqf_scaled = dataset.SHO_scaler.transform(lsqf_phys)
+    spread_nn = float(np.mean(np.std(nn_scaled, axis=0)))
+    spread_lsqf = float(np.mean(np.std(lsqf_scaled, axis=0)))
+    rows.append((k, mse_lsqf, mse_nn, spread_lsqf, spread_nn))
+    print(f"noise {k}: median MSE  LSQF={mse_lsqf:.5f}  NN={mse_nn:.5f} | "
+          f"mean param std  LSQF={spread_lsqf:.4f}  NN={spread_nn:.4f}", flush=True)
+
+rows = np.array(rows)
+print("\nPRIORITY 5 table (noise, medMSE_LSQF, medMSE_NN, spread_LSQF, spread_NN):")
+for r in rows:
+    print(f"  {int(r[0])}  {r[1]:.5f}  {r[2]:.5f}  {r[3]:.4f}  {r[4]:.4f}")
+
+fig, (a1, a2) = plt.subplots(1, 2, figsize=(12, 4.2))
+a1.plot(rows[:, 0], rows[:, 1], "-o", color=LSQF_C, label="LSQF")
+a1.plot(rows[:, 0], rows[:, 2], "-o", color=NN_C, label="NN")
+a1.set_xlabel("noise factor"); a1.set_ylabel("median reconstruction MSE")
+a1.set_title("Reconstruction MSE vs noise"); a1.legend(frameon=False)
+a2.plot(rows[:, 0], rows[:, 3], "-o", color=LSQF_C, label="LSQF")
+a2.plot(rows[:, 0], rows[:, 4], "-o", color=NN_C, label="NN")
+a2.set_xlabel("noise factor"); a2.set_ylabel("mean scaled-param std")
+a2.set_title("Parameter spread vs noise"); a2.legend(frameon=False)
+fig.tight_layout()
+fig.savefig("./Figures/Figure_accuracy_vs_noise.png", dpi=300, bbox_inches="tight")
+fig.savefig("./Figures/Figure_accuracy_vs_noise.svg", bbox_inches="tight")
+plt.close(fig)
+print("\nWrote ./Figures/Figure_accuracy_vs_noise.png and .svg")
+print("DONE P5")

--- a/m3_learning/papers/2023_Rapid_Fitting/analysis_p5_pernoise.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/analysis_p5_pernoise.py
@@ -1,0 +1,104 @@
+"""Accuracy/robustness vs noise — PER-NOISE best Adam models (find_best_model),
+matching the noise violin / p6. Panel (a): median per-spectrum reconstruction MSE.
+Panel (b): FRACTION of recovered SHO parameters strictly outside the physically
+admissible ranges (A,(0,1.5e-4); omega_0,(1.31e6,1.33e6); Q,(-300,0); phi wrapped
+to (-pi,pi) -> never out), for LSQF and the network, n=0..8. Overwrites
+./Figures/Figure_accuracy_vs_noise.{png,svg}.
+"""
+import glob
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn, find_best_model
+from m3_learning.nn.Fitter1D.Fitter1D import Multiscale1DFitter, Model, ComplexPostProcessor
+
+import sys as _s, os as _o
+_s.path.insert(0, _o.path.dirname(_o.path.abspath(__file__)))
+from pubstyle import set_pub_style, METHOD_COLORS, SEQ_CMAP
+
+DATA = "Data/data_raw.h5"
+LSQF_C, NN_C = METHOD_COLORS["LSQF"], METHOD_COLORS["NN"]
+RANGES = [(0, 1.5e-4), (1.31e6, 1.33e6), (-300, 0), (-np.pi, np.pi)]
+
+set_style("printing"); random_seed(seed=42); set_pub_style()
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+dataset.SHO_Fitter(force=False, h5_sho_targ_grp="Raw_Data_SHO_Fit")
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+
+basepath = sorted(glob.glob("Trained Models/SHO Fitter/*_nn_benchmarks_noise"))[-1]
+results = find_best_model(basepath, "Batch_Trainging_SpeedTest.csv")
+
+def load_adam(noise):
+    ck = basepath + "/" + results[(noise, "Adam")]['filename'].split("//")[-1]
+    fitter = Multiscale1DFitter(SHO_fit_func_nn, dataset.frequency_bin, 2, 4,
+                                dataset.SHO_scaler, ComplexPostProcessor(dataset))
+    m = Model(fitter, dataset, training=False, model_basename="SHO_Fitter_original_data")
+    m.load(ck)
+    return m
+
+def to_arr(lst):
+    return np.rollaxis(np.array(lst), 0, 3)
+
+def frac_out_of_range(P):
+    """fraction of individual parameter values strictly outside RANGES; phi is
+    wrapped to (-pi,pi] first so it is never counted as unphysical (it is circular)."""
+    P = np.asarray(P).astype(float).copy()
+    P[:, 3] = np.angle(np.exp(1j * P[:, 3]))      # wrap phi
+    out = 0
+    for i, (lo, hi) in enumerate(RANGES):
+        out += int(np.sum((P[:, i] < lo) | (P[:, i] > hi)))
+    return out / P.size                            # P.size = N * 4
+
+base = {"fitter": "LSQF", "raw_format": "complex", "resampled": True,
+        "scaled": True, "output_shape": "index", "measurement_state": "all"}
+
+rows = []
+for k in range(9):
+    st = dict(base); st["noise"] = k
+    dataset.set_attributes(**st)
+    model = load_adam(k)                      # PER-NOISE best Adam model
+    X, _ = dataset.NN_data()
+    _, _, nn_phys = model.predict(X)
+    nn_phys = np.asarray(nn_phys)
+    dataset.set_attributes(**st); dataset.scaled = False
+    lsqf_phys = dataset.SHO_fit_results().reshape(-1, 4)
+    dataset.scaled = True
+    true_list, _ = dataset.raw_spectra(frequency=True)
+    nn_recon, _ = dataset.raw_spectra(fit_results=nn_phys, frequency=True)
+    lsqf_recon, _ = dataset.raw_spectra(fit_results=lsqf_phys, frequency=True)
+    t = to_arr(true_list)
+    mse_nn = float(np.median(Model.MSE(t, to_arr(nn_recon))))
+    mse_lsqf = float(np.median(Model.MSE(t, to_arr(lsqf_recon))))
+    oor_lsqf = frac_out_of_range(lsqf_phys)
+    oor_nn = frac_out_of_range(nn_phys)
+    rows.append((k, mse_lsqf, mse_nn, oor_lsqf, oor_nn))
+    print(f"noise {k}: medMSE LSQF={mse_lsqf:.5f} NN={mse_nn:.5f} | "
+          f"fracOOR LSQF={oor_lsqf:.5f} NN={oor_nn:.6f}", flush=True)
+
+rows = np.array(rows)
+print("\nPER-NOISE table (noise, medMSE_LSQF, medMSE_NN, fracOOR_LSQF, fracOOR_NN):")
+for r in rows:
+    print(f"  {int(r[0])}  {r[1]:.5f}  {r[2]:.5f}  {r[3]:.5f}  {r[4]:.6f}")
+
+fig, (a1, a2) = plt.subplots(1, 2, figsize=(12, 4.2))
+a1.plot(rows[:, 0], rows[:, 1], "-o", color=LSQF_C, label="LSQF")
+a1.plot(rows[:, 0], rows[:, 2], "-o", color=NN_C, label="NN")
+a1.set_xlabel("Noise factor"); a1.set_ylabel("Median reconstruction MSE")
+a1.set_title("Reconstruction MSE vs noise"); a1.legend(frameon=False)
+
+a2.plot(rows[:, 0], rows[:, 3], "-o", color=LSQF_C, label="LSQF")
+a2.plot(rows[:, 0], rows[:, 4], "-o", color=NN_C, label="NN")
+a2.set_xlabel("Noise factor"); a2.set_ylabel("Fraction of parameters out of range")
+a2.set_ylim(0, 1); a2.set_title("Unphysical parameters vs noise"); a2.legend(frameon=False)
+
+fig.tight_layout()
+fig.savefig("./Figures/Figure_accuracy_vs_noise.png", dpi=300, bbox_inches="tight")
+fig.savefig("./Figures/Figure_accuracy_vs_noise.svg", bbox_inches="tight")
+plt.close(fig)
+print("\nWrote ./Figures/Figure_accuracy_vs_noise.png and .svg (panel b = fraction out of range)")
+print("DONE")

--- a/m3_learning/papers/2023_Rapid_Fitting/build_noise_violin.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/build_noise_violin.py
@@ -1,0 +1,96 @@
+"""Figure_noise_violin: split-violin of the 4 SCALED SHO params (A, omega_0, Q, phi),
+LSQF vs network, for noise n=0,4,7. Network = per-noise best Adam model (nb4
+find_best_model), same source as p6a/p6b. Styling matches the fixed
+violin_plot_comparison. NO retraining.
+"""
+import glob
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn, find_best_model
+from m3_learning.nn.Fitter1D.Fitter1D import Multiscale1DFitter, Model, ComplexPostProcessor
+
+DATA = "Data/data_raw.h5"
+LSQF_C, NN_C = "#0072B2", "#E69F00"
+LABELS = ["A", "ω", "Q", "φ"]   # A, omega, Q, phi (match violin_plot_comparison)
+NOISES = [0, 4, 7]
+
+set_style("printing"); random_seed(seed=42)
+import sys as _s, os as _o
+_s.path.insert(0, _o.path.dirname(_o.path.abspath(__file__)))
+from pubstyle import set_pub_style, METHOD_COLORS, SEQ_CMAP
+set_pub_style()
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+dataset.SHO_Fitter(force=False, h5_sho_targ_grp="Raw_Data_SHO_Fit")
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+
+basepath = sorted(glob.glob("Trained Models/SHO Fitter/*_nn_benchmarks_noise"))[-1]
+results = find_best_model(basepath, "Batch_Trainging_SpeedTest.csv")
+
+def load_adam(noise):
+    ck = basepath + "/" + results[(noise, "Adam")]['filename'].split("//")[-1]
+    fitter = Multiscale1DFitter(SHO_fit_func_nn, dataset.frequency_bin, 2, 4,
+                                dataset.SHO_scaler, ComplexPostProcessor(dataset))
+    m = Model(fitter, dataset, training=False, model_basename="SHO_Fitter_original_data")
+    m.load(ck)
+    return m
+
+state = {"fitter": "LSQF", "raw_format": "complex", "resampled": True, "scaled": True,
+         "output_shape": "index", "measurement_state": "all"}
+
+frames = {}
+counts = {}
+for n in NOISES:
+    st = dict(state); st["noise"] = n
+    dataset.set_attributes(**st)
+    model = load_adam(n)
+    X, _ = dataset.NN_data()
+    _, _, nn_phys = model.predict(X)
+    nn_scaled = dataset.SHO_scaler.transform(np.asarray(nn_phys))   # NN scaled (violin recipe)
+    dataset.set_attributes(**st)
+    lsqf_scaled = dataset.SHO_fit_results().reshape(-1, 4)          # LSQF scaled (violin 'true')
+    counts[n] = X.shape[0]
+    df = pd.DataFrame()
+    for arr, meth in [(lsqf_scaled, "LSQF"), (nn_scaled, "NN")]:
+        for i, lab in enumerate(LABELS):
+            df = pd.concat((df, pd.DataFrame({
+                "value": arr[:, i],
+                "parameter": np.repeat(lab, arr.shape[0]),
+                "method": np.repeat(meth, arr.shape[0]),
+            })), ignore_index=True)
+    frames[n] = df
+    print(f"noise {n}: best Adam model = {results[(n,'Adam')]['filename'].split('//')[-1]}  "
+          f"n_spectra = {X.shape[0]}", flush=True)
+
+# 3 panels, shared y
+fig, axes = plt.subplots(1, 3, figsize=(15, 4), sharey=True)
+for ax, n in zip(axes, NOISES):
+    sns.violinplot(data=frames[n], x="parameter", y="value", hue="method", split=True,
+                   inner="quart", cut=0, density_norm="width", linewidth=0.8,
+                   palette={"LSQF": LSQF_C, "NN": NN_C}, ax=ax)
+    ax.axhline(0, color="0.6", lw=0.5, zorder=0)
+    ax.set_xlabel(""); ax.set_title(f"noise factor {n}", fontsize=11)
+    ax.set_ylim(-5, 5)
+    if ax.get_legend() is not None:
+        ax.get_legend().remove()
+    sns.despine(ax=ax)
+axes[0].set_ylabel("Scaled SHO parameter")
+# one shared legend
+handles = [plt.Rectangle((0, 0), 1, 1, color=c) for c in (LSQF_C, NN_C)]
+fig.legend(handles, ["LSQF", "NN"], frameon=False, loc="upper right",
+           bbox_to_anchor=(0.995, 0.99), ncol=2)
+fig.tight_layout(rect=[0, 0, 1, 0.96])
+fig.savefig("./Figures/Figure_noise_violin.png", dpi=300, bbox_inches="tight")
+fig.savefig("./Figures/Figure_noise_violin.svg", bbox_inches="tight")
+plt.close(fig)
+print(f"\nUsed noise levels: {NOISES}")
+print("spectra per level:", {n: counts[n] for n in NOISES})
+print("Wrote ./Figures/Figure_noise_violin.png and .svg")
+print("DONE noise_violin")

--- a/m3_learning/papers/2023_Rapid_Fitting/p6ab.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/p6ab.py
@@ -1,0 +1,98 @@
+"""P6a: Fig-3 noise histograms (n=4, n=7), rows = LSQF / network-Adam / network-TR-CG,
+consistent palette. P6b: SI switching maps (n=7) with 'SGD'->'TR-CG' label.
+Models = per-(noise,optimizer) best from the 2_5 benchmark (nb4 find_best_model recipe).
+"""
+import glob
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.viz.printing import printer
+from m3_learning.be.viz import Viz
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn, find_best_model
+from m3_learning.nn.Fitter1D.Fitter1D import Multiscale1DFitter, Model, ComplexPostProcessor
+
+LSQF_C, NN_C, TR_C = "#0072B2", "#E69F00", "#009E73"
+LABELS = ["A", r"$\omega_0$", "Q", r"$\varphi$"]
+RANGES = [(0, 1.5e-4), (1.31e6, 1.33e6), (-300, 0), (-np.pi, np.pi)]
+DATA = "Data/data_raw.h5"
+
+set_style("printing"); random_seed(seed=42)
+import sys as _s, os as _o
+_s.path.insert(0, _o.path.dirname(_o.path.abspath(__file__)))
+from pubstyle import set_pub_style, METHOD_COLORS, SEQ_CMAP
+set_pub_style()
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+dataset.SHO_Fitter(force=False, h5_sho_targ_grp="Raw_Data_SHO_Fit")
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+printing = printer(basepath="./Figures/")
+BE_viz = Viz(dataset, printing, verbose=False, SHO_ranges=RANGES,
+             image_scalebar=[2000, 500, "nm", "br"])
+
+# nb4 recipe: best per-(noise,optimizer) model from the 2_5 benchmark
+basepath = sorted(glob.glob("Trained Models/SHO Fitter/*_nn_benchmarks_noise"))[-1]
+results = find_best_model(basepath, "Batch_Trainging_SpeedTest.csv")
+print("benchmark:", basepath)
+
+def load_nn_model(ckpt):
+    fitter = Multiscale1DFitter(SHO_fit_func_nn, dataset.frequency_bin, 2, 4,
+                                dataset.SHO_scaler, ComplexPostProcessor(dataset))
+    m = Model(fitter, dataset, training=False, model_basename="SHO_Fitter_original_data")
+    m.load(ckpt)
+    return m
+
+def models_for(noise):
+    a = basepath + "/" + results[(noise, "Adam")]['filename'].split("//")[-1]
+    t = basepath + "/" + results[(noise, "Trust Region CG")]['filename'].split("//")[-1]
+    return load_nn_model(a), load_nn_model(t)
+
+def get_params(noise, model_adam, model_tr):
+    st = {"resampled": True, "raw_format": "complex", "fitter": "LSQF", "scaled": False,
+          "output_shape": "index", "measurement_state": "all", "resampled_bins": 165,
+          "LSQF_phase_shift": np.pi / 2, "NN_phase_shift": None, "noise": noise}
+    dataset.set_attributes(**st)
+    lsqf = np.asarray(dataset.SHO_fit_results(state=st)).reshape(-1, 4)
+    X, _ = dataset.NN_data()
+    adam = np.asarray(dataset.SHO_fit_results(model=model_adam, phase_shift=np.pi / 2, X_data=X)).reshape(-1, 4)
+    tr = np.asarray(dataset.SHO_fit_results(model=model_tr, phase_shift=np.pi / 2, X_data=X)).reshape(-1, 4)
+    return lsqf, adam, tr
+
+# ---------- P6a: histograms for noise 4 and 7 ----------
+for noise in (4, 7):
+    ma, mt = models_for(noise)
+    lsqf, adam, tr = get_params(noise, ma, mt)
+    rows = [("LSQF", lsqf, LSQF_C), ("network – Adam", adam, NN_C), ("network – TR-CG", tr, TR_C)]
+    fig, axes = plt.subplots(3, 4, figsize=(13, 8))
+    for r, (rlab, P, c) in enumerate(rows):
+        for j in range(4):
+            ax = axes[r, j]
+            lo, hi = RANGES[j]
+            ax.hist(np.clip(P[:, j], lo, hi), bins=120, range=(lo, hi), color=c)
+            if r == 0:
+                ax.set_title(LABELS[j])
+            if j == 0:
+                ax.set_ylabel(rlab + "\ncount", fontsize=11)
+            ax.ticklabel_format(axis="x", style="sci", scilimits=(-2, 4))
+    fig.suptitle(f"SHO parameter histograms — noise factor {noise}  "
+                 f"(rows: LSQF / network-Adam / network-TR-CG)", y=1.0)
+    fig.tight_layout()
+    fig.savefig(f"./Figures/Figure_3_histograms_noise{noise}.png", dpi=300, bbox_inches="tight")
+    fig.savefig(f"./Figures/Figure_3_histograms_noise{noise}.svg", bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote ./Figures/Figure_3_histograms_noise{noise}.png and .svg", flush=True)
+
+# ---------- P6b: switching maps n=7 ----------
+noise = 7
+ma, mt = models_for(noise)
+lsqf, adam, tr = get_params(noise, ma, mt)
+BE_viz.SHO_switching_maps_test(
+    [lsqf, adam, tr],
+    filename=f"Figure_5_47_switching_maps_comparison_{noise}_noise",
+    labels=["LSQF", "Adam", "TR-CG"],
+)
+print(f"Wrote ./Figures/Figure_5_47_switching_maps_comparison_{noise}_noise.png and .svg", flush=True)
+print("DONE P6ab", flush=True)

--- a/m3_learning/papers/2023_Rapid_Fitting/p6c.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/p6c.py
@@ -1,0 +1,59 @@
+"""P6c: Fig 4c — AdaHessian best/median/worst reconstructions, regenerated at high dpi
+in the consistent palette. Loads the AdaHessian SHO checkpoint (NO retraining) and
+mirrors nb3's get_best_median_worst + SHO_Fit_comparison recipe.
+"""
+import numpy as np
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.viz.printing import printer
+from m3_learning.be.viz import Viz
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn, SHO_Model
+
+DATA = "Data/data_raw.h5"
+ADAH = ("Trained Models/SHO Fitter/"
+        "SHO_Fitter_original_data_adahessian_model_optimizer_AdaHessian_epoch_4_train_loss_0.6511134322650766.pth")
+RANGES = [(0, 1.5e-4), (1.31e6, 1.33e6), (-300, 0), (-np.pi, np.pi)]
+
+set_style("printing"); random_seed(seed=42)
+import sys as _s, os as _o
+_s.path.insert(0, _o.path.dirname(_o.path.abspath(__file__)))
+from pubstyle import set_pub_style, METHOD_COLORS, SEQ_CMAP
+set_pub_style()
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+dataset.SHO_Fitter(force=False, h5_sho_targ_grp="Raw_Data_SHO_Fit")
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+printing = printer(basepath="./Figures/")
+BE_viz = Viz(dataset, printing, verbose=False, SHO_ranges=RANGES,
+             image_scalebar=[2000, 500, "nm", "br"])
+
+# nb3 builds the AdaHessian model as a SHO_Model (AE_Fitter_SHO architecture), not the
+# Multiscale1DFitter wrapper -- load the saved weights into the matching class (no retraining)
+ADAHessian_model = SHO_Model(dataset, training=True,
+                             model_basename="SHO_Fitter_original_data_adahessian")
+ADAHessian_model.load(ADAH)
+
+dataset.NN_phase_shift = np.pi / 2
+dataset.LSQF_phase_shift = np.pi / 2
+dataset.measurement_state = "all"
+
+true_state = {"fitter": "LSQF", "raw_format": "complex", "resampled": True,
+              "scaled": True, "output_shape": "index", "measurement_state": "all"}
+out_state = {"scaled": True, "raw_format": "magnitude spectrum"}
+
+LSQF = BE_viz.get_best_median_worst(true_state, prediction={"fitter": "LSQF"},
+                                    out_state=out_state, SHO_results=True, n=1)
+NN = BE_viz.get_best_median_worst(true_state, prediction=ADAHessian_model,
+                                  out_state=out_state, SHO_results=True, n=1)
+
+# SHO_Fit_comparison keys an internal color_palette by name; only "LSQF"/"NN" exist
+# (each with _A/_P for the amplitude/phase channels). The "NN" row IS the AdaHessian model.
+BE_viz.SHO_Fit_comparison(
+    (LSQF, NN), ["LSQF", "NN"],
+    model_comparison=[ADAHessian_model, {"fitter": "LSQF"}],
+    out_state=out_state,
+    size=(1.7, 1.7), gaps=(1.9, 1.9),   # roomier panels so labels don't overlap
+    filename="Figure_4c_AdaHessian_bmw",
+)
+print("Wrote ./Figures/Figure_4c_AdaHessian_bmw.png and .svg")
+print("DONE P6c")

--- a/m3_learning/papers/2023_Rapid_Fitting/p6d.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/p6d.py
@@ -1,0 +1,41 @@
+"""P6d: hysteresis loop-parameter violin (LSQF vs network), using the fixed
+violin_plot_comparison_hysteresis and the hysteresis Trust-Region-CG checkpoint.
+Mirrors nb5 cells 13 + 19 (NO retraining)."""
+import numpy as np
+import torch
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.viz.printing import printer
+from m3_learning.be.viz import Viz
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn
+from m3_learning.be.loop_fitter import loop_fitting_function_torch
+from m3_learning.nn.Fitter1D.Fitter1D import Multiscale1DFitter, Model
+
+DATA = "Data/data_raw.h5"
+HYST = ("Trained Models/Hysteresis Fitter/"
+        "Hysteresis_Loop_Fitter_model_optimizer_Trust Region CG_epoch_599_train_loss_0.006081502470705245.pth")
+
+set_style("printing"); random_seed(seed=42)
+import sys as _s, os as _o
+_s.path.insert(0, _o.path.dirname(_o.path.abspath(__file__)))
+from pubstyle import set_pub_style, METHOD_COLORS, SEQ_CMAP
+set_pub_style()
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+printing = printer(basepath="./Figures/")
+BE_viz = Viz(dataset, printing, verbose=False, image_scalebar=[2000, 500, "nm", "br"])
+
+# hysteresis data + scalers (cached LSQF loop fit must exist in the h5)
+data, voltage = dataset.get_hysteresis(scaled=True, loop_interpolated=True)
+
+model_ = Multiscale1DFitter(loop_fitting_function_torch, voltage[:, 0].squeeze(),
+                            1, 9, dataset.loop_param_scaler,
+                            loops_scaler=dataset.hysteresis_scaler)
+model = Model(model_, dataset, path='Trained Models/Hysteresis Fitter/',
+              training=True, model_basename="Hysteresis_Loop_Fitter")
+model.load(HYST)
+
+X = torch.atleast_3d(torch.Tensor(data).reshape(-1, 96))
+BE_viz.violin_plot_comparison_hysteresis(model, X, filename="Figure_hysteresis_violin")
+print("Wrote ./Figures/Figure_hysteresis_violin.png and .svg")
+print("DONE P6d")

--- a/m3_learning/papers/2023_Rapid_Fitting/phi_wrap.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/phi_wrap.py
@@ -1,0 +1,38 @@
+"""Circular (wrapped) phi agreement — the honest manuscript numbers for phi, since the
+raw linear stats are dominated by 2pi wrapping / branch convention."""
+import numpy as np
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn
+from m3_learning.nn.Fitter1D.Fitter1D import Multiscale1DFitter, Model, ComplexPostProcessor
+
+DATA = "Data/data_raw.h5"
+CKPT = ("Trained Models/SHO Fitter/"
+        "SHO_Fitter_original_data_model_optimizer_Adam_epoch_4_train_loss_0.03403592322973526.pth")
+set_style("printing"); random_seed(seed=42)
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+dataset.SHO_Fitter(force=False, h5_sho_targ_grp="Raw_Data_SHO_Fit")
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+st = {"fitter": "LSQF", "raw_format": "complex", "resampled": True, "scaled": True,
+      "output_shape": "index", "measurement_state": "all"}
+dataset.set_attributes(**st)
+post = ComplexPostProcessor(dataset)
+m_ = Multiscale1DFitter(SHO_fit_func_nn, dataset.frequency_bin, 2, 4, dataset.SHO_scaler, post)
+model = Model(m_, dataset, training=True, model_basename="SHO_Fitter_original_data")
+model.load(CKPT)
+_, _, nn = model.predict(dataset.NN_data()[0]); nn = np.asarray(nn)
+dataset.scaled = False
+lsqf = dataset.SHO_fit_results().reshape(-1, 4)
+nphi, lphi = nn[:, 3], lsqf[:, 3]
+# wrap the difference to (-pi, pi]
+dwrap = np.angle(np.exp(1j * (nphi - lphi)))
+# align NN phase onto the LSQF branch, then check genuinely-out-of-range
+nphi_wrapped = np.angle(np.exp(1j * nphi))
+n = len(nphi)
+print(f"n = {n}")
+print(f"phi  median|wrapped diff| = {np.median(np.abs(dwrap)):.4f} rad")
+print(f"phi  IQR(wrapped diff)    = {np.percentile(dwrap,75)-np.percentile(dwrap,25):.4f} rad")
+print(f"phi  circular agreement: frac |wrapped diff| < 0.5 rad = {np.mean(np.abs(dwrap)<0.5):.4f}")
+print(f"phi  NN out of (-pi,pi) RAW     = {np.mean((nphi< -np.pi)|(nphi>np.pi))*100:.3f}%")
+print(f"phi  NN out of (-pi,pi) WRAPPED = {np.mean((nphi_wrapped< -np.pi)|(nphi_wrapped>np.pi))*100:.3f}%")

--- a/m3_learning/papers/2023_Rapid_Fitting/regen_fig14.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/regen_fig14.py
@@ -48,7 +48,7 @@ BE_viz.SHO_Fit_comparison(
     (LSQF, NN), ["LSQF", "NN"],
     model_comparison=[model, {"fitter": "LSQF"}],
     out_state=out_state,
-    size=(1.7, 1.7), gaps=(1.9, 1.9),   # roomier panels so the bigger pub-style labels don't overlap
+    size=(2.7, 1.5), gaps=(1.3, 0.75),   # roomier panels so the bigger pub-style labels don't overlap
     filename="Figure_14_LSQF_NN_bmw_comparison",
 )
 print("Wrote ./Figures/Figure_14_LSQF_NN_bmw_comparison.png and .svg")

--- a/m3_learning/papers/2023_Rapid_Fitting/regen_fig14.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/regen_fig14.py
@@ -1,0 +1,55 @@
+"""Regenerate Figure_14_LSQF_NN_bmw_comparison (SHO best/median/worst, nb2 recipe)
+with the corrected shared legend. Loads the Adam epoch-4 checkpoint, no retraining."""
+import numpy as np
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.viz.printing import printer
+from m3_learning.be.viz import Viz
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn
+from m3_learning.nn.Fitter1D.Fitter1D import Multiscale1DFitter, Model, ComplexPostProcessor
+
+DATA = "Data/data_raw.h5"
+ADAM = ("Trained Models/SHO Fitter/"
+        "SHO_Fitter_original_data_model_optimizer_Adam_epoch_4_train_loss_0.03403592322973526.pth")
+RANGES = [(0, 1.5e-4), (1.31e6, 1.33e6), (-300, 0), (-np.pi, np.pi)]
+
+set_style("printing"); random_seed(seed=42)
+import sys as _s, os as _o
+_s.path.insert(0, _o.path.dirname(_o.path.abspath(__file__)))
+from pubstyle import set_pub_style, METHOD_COLORS, SEQ_CMAP
+set_pub_style()
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+dataset.SHO_Fitter(force=False, h5_sho_targ_grp="Raw_Data_SHO_Fit")
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+printing = printer(basepath="./Figures/")
+BE_viz = Viz(dataset, printing, verbose=False, SHO_ranges=RANGES,
+             image_scalebar=[2000, 500, "nm", "br"])
+
+post = ComplexPostProcessor(dataset)
+m_ = Multiscale1DFitter(SHO_fit_func_nn, dataset.frequency_bin, 2, 4, dataset.SHO_scaler, post)
+model = Model(m_, dataset, training=True, model_basename="SHO_Fitter_original_data")
+model.load(ADAM)
+
+dataset.NN_phase_shift = np.pi / 2
+dataset.LSQF_phase_shift = np.pi / 2
+dataset.measurement_state = "all"
+
+true_state = {"fitter": "LSQF", "raw_format": "complex", "resampled": True,
+              "scaled": True, "output_shape": "index", "measurement_state": "all"}
+out_state = {"scaled": True, "raw_format": "magnitude spectrum"}
+
+LSQF = BE_viz.get_best_median_worst(true_state, prediction={"fitter": "LSQF"},
+                                    out_state=out_state, SHO_results=True, n=1)
+NN = BE_viz.get_best_median_worst(true_state, prediction=model,
+                                  out_state=out_state, SHO_results=True, n=1)
+
+BE_viz.SHO_Fit_comparison(
+    (LSQF, NN), ["LSQF", "NN"],
+    model_comparison=[model, {"fitter": "LSQF"}],
+    out_state=out_state,
+    size=(1.7, 1.7), gaps=(1.9, 1.9),   # roomier panels so the bigger pub-style labels don't overlap
+    filename="Figure_14_LSQF_NN_bmw_comparison",
+)
+print("Wrote ./Figures/Figure_14_LSQF_NN_bmw_comparison.png and .svg")
+print("DONE fig14")

--- a/m3_learning/papers/2023_Rapid_Fitting/regen_fig15.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/regen_fig15.py
@@ -1,0 +1,40 @@
+"""Regenerate Figure_15_NN_Switching_Maps (single-model NN parameter maps, nb2/nb6
+recipe) with cividis + pub style. Adam epoch-4 model on noise-0 data, no retraining."""
+import numpy as np
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.viz.printing import printer
+from m3_learning.be.viz import Viz
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn
+from m3_learning.nn.Fitter1D.Fitter1D import Multiscale1DFitter, Model, ComplexPostProcessor
+
+import sys as _s, os as _o
+_s.path.insert(0, _o.path.dirname(_o.path.abspath(__file__)))
+from pubstyle import set_pub_style, METHOD_COLORS, SEQ_CMAP
+
+DATA = "Data/data_raw.h5"
+ADAM = ("Trained Models/SHO Fitter/"
+        "SHO_Fitter_original_data_model_optimizer_Adam_epoch_4_train_loss_0.03403592322973526.pth")
+RANGES = [(0, 1.5e-4), (1.31e6, 1.33e6), (-300, 0), (-np.pi, np.pi)]
+
+set_style("printing"); random_seed(seed=42); set_pub_style()
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+dataset.SHO_Fitter(force=False, h5_sho_targ_grp="Raw_Data_SHO_Fit")
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+printing = printer(basepath="./Figures/")
+BE_viz = Viz(dataset, printing, verbose=False, SHO_ranges=RANGES,
+             image_scalebar=[2000, 500, "nm", "br"])
+
+dataset.set_attributes(fitter="LSQF", raw_format="complex", resampled=True,
+                       scaled=True, output_shape="index", measurement_state="all", noise=0)
+post = ComplexPostProcessor(dataset)
+m_ = Multiscale1DFitter(SHO_fit_func_nn, dataset.frequency_bin, 2, 4, dataset.SHO_scaler, post)
+model = Model(m_, dataset, training=False, model_basename="SHO_Fitter_original_data")
+model.load(ADAM)
+
+X_data, _ = dataset.NN_data()
+_, _, parm = model.predict(X_data)
+BE_viz.SHO_switching_maps(np.asarray(parm), filename="Figure_15_NN_Switching_Maps")
+print("Wrote ./Figures/Figure_15_NN_Switching_Maps.png and .svg")
+print("DONE fig15")

--- a/m3_learning/papers/2023_Rapid_Fitting/regen_hyst_comp.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/regen_hyst_comp.py
@@ -1,0 +1,42 @@
+"""Regenerate hysteresis_comparison (nb5 recipe) with the corrected shared legend.
+Loads the hysteresis Trust-Region-CG checkpoint, no retraining."""
+import numpy as np
+import torch
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.viz.printing import printer
+from m3_learning.be.viz import Viz
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn
+from m3_learning.be.loop_fitter import loop_fitting_function_torch
+from m3_learning.nn.Fitter1D.Fitter1D import Multiscale1DFitter, Model
+
+DATA = "Data/data_raw.h5"
+HYST = ("Trained Models/Hysteresis Fitter/"
+        "Hysteresis_Loop_Fitter_model_optimizer_Trust Region CG_epoch_599_train_loss_0.006081502470705245.pth")
+
+set_style("printing"); random_seed(seed=42)
+import sys as _s, os as _o
+_s.path.insert(0, _o.path.dirname(_o.path.abspath(__file__)))
+from pubstyle import set_pub_style, METHOD_COLORS, SEQ_CMAP
+set_pub_style()
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+printing = printer(basepath="./Figures/")
+BE_viz = Viz(dataset, printing, verbose=False, image_scalebar=[2000, 500, "nm", "br"])
+
+# hysteresis data + scalers (cached LSQF loop fit in the h5)
+data, voltage = dataset.get_hysteresis(scaled=True, loop_interpolated=True)
+model_ = Multiscale1DFitter(loop_fitting_function_torch, voltage[:, 0].squeeze(),
+                            1, 9, dataset.loop_param_scaler,
+                            loops_scaler=dataset.hysteresis_scaler)
+model = Model(model_, dataset, path='Trained Models/Hysteresis Fitter/',
+              training=True, model_basename="Hysteresis_Loop_Fitter")
+model.load(HYST)
+
+BE_viz.hysteresis_comparison(['LSQF', 'NN'],
+                             row=None, col=None, cycle=None,
+                             size=(1.25, 1.25), gaps=(0.8, 0.4),
+                             nn_model=model, measurement_state=None,
+                             filename="hysteresis_comparison")
+print("Wrote ./Figures/hysteresis_comparison.png and .svg")
+print("DONE hyst_comp")

--- a/m3_learning/papers/2023_Rapid_Fitting/regen_hyst_comp.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/regen_hyst_comp.py
@@ -35,7 +35,7 @@ model.load(HYST)
 
 BE_viz.hysteresis_comparison(['LSQF', 'NN'],
                              row=None, col=None, cycle=None,
-                             size=(1.25, 1.25), gaps=(0.8, 0.4),
+                             size=(1.25, 1.25), gaps=(0.9, 0.9),
                              nn_model=model, measurement_state=None,
                              filename="hysteresis_comparison")
 print("Wrote ./Figures/hysteresis_comparison.png and .svg")

--- a/m3_learning/papers/2023_Rapid_Fitting/regen_switchmaps.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/regen_switchmaps.py
@@ -1,0 +1,173 @@
+"""Clean-layout SHO switching-maps grids (Figure_5_47 noise-7 LSQF/Adam/TR-CG, and
+Figure_15 noise-0 Adam single method). Full content kept: 9 steps x 4 params x N
+methods. Built from scratch with explicit axes geometry so row labels, column
+headers, step numbers and per-parameter colorbars never collide. cividis, square
+tiles, landscape SI canvas."""
+import glob
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.colors import Normalize
+from matplotlib.cm import ScalarMappable
+
+import sys as _s, os as _o
+_s.path.insert(0, _o.path.dirname(_o.path.abspath(__file__)))
+from pubstyle import set_pub_style, SEQ_CMAP
+
+from m3_learning.nn.random import random_seed
+from m3_learning.viz.style import set_style
+from m3_learning.be.dataset import BE_Dataset
+from m3_learning.be.nn import SHO_fit_func_nn, find_best_model
+from m3_learning.nn.Fitter1D.Fitter1D import Multiscale1DFitter, Model, ComplexPostProcessor
+
+DATA = "Data/data_raw.h5"
+ADAM0 = ("Trained Models/SHO Fitter/"
+         "SHO_Fitter_original_data_model_optimizer_Adam_epoch_4_train_loss_0.03403592322973526.pth")
+NAMES = ["A", "ω₀", "Q", "φ"]
+CLIMS = [(0, 1.4e-4), (1.31e6, 1.33e6), (-230, -160), (-np.pi, np.pi)]
+NSTEP = 9
+
+set_style("printing"); random_seed(seed=42); set_pub_style()
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+dataset.SHO_Fitter(force=False, h5_sho_targ_grp="Raw_Data_SHO_Fit")
+dataset = BE_Dataset(DATA, SHO_fit_func_LSQF=SHO_fit_func_nn)
+basepath = sorted(glob.glob("Trained Models/SHO Fitter/*_nn_benchmarks_noise"))[-1]
+results = find_best_model(basepath, "Batch_Trainging_SpeedTest.csv")
+SIDE = int(round(np.sqrt(dataset.num_pix)))
+
+
+def load_model(noise, opt):
+    ck = basepath + "/" + results[(noise, opt)]['filename'].split("//")[-1]
+    fitter = Multiscale1DFitter(SHO_fit_func_nn, dataset.frequency_bin, 2, 4,
+                                dataset.SHO_scaler, ComplexPostProcessor(dataset))
+    m = Model(fitter, dataset, training=False, model_basename="SHO_Fitter_original_data")
+    m.load(ck)
+    return m
+
+
+def get_params(noise, models):
+    """returns list of physical param arrays [N,4] for LSQF + each model."""
+    st = {"resampled": True, "raw_format": "complex", "fitter": "LSQF", "scaled": False,
+          "output_shape": "index", "measurement_state": "all", "resampled_bins": 165,
+          "LSQF_phase_shift": np.pi / 2, "NN_phase_shift": None, "noise": noise}
+    dataset.set_attributes(**st)
+    out = [np.asarray(dataset.SHO_fit_results(state=st)).reshape(-1, 4)]
+    X, _ = dataset.NN_data()
+    for m in models:
+        out.append(np.asarray(dataset.SHO_fit_results(model=m, phase_shift=np.pi / 2, X_data=X)).reshape(-1, 4))
+    return out
+
+
+def to_maps(params):
+    """physical [N,4] -> (num_pix, cycle_steps, 4) off-state cycle-2 maps."""
+    dataset.measurement_state = "off"; dataset.cycle = 2
+    a = np.asarray(params).reshape(dataset.num_pix, dataset.voltage_steps, 4)
+    a = dataset.get_measurement_cycle(a, cycle=2, axis=1)
+    return np.asarray(a)
+
+
+def cycle_voltage():
+    dataset.measurement_state = "off"; dataset.cycle = 2
+    v = dataset.dc_voltage
+    v = dataset.get_cycle(v)
+    return np.asarray(v).squeeze()
+
+
+def plot_grid(method_arrays, labels, filename):
+    nm = len(method_arrays)
+    steps = method_arrays[0].shape[1]
+    inds = np.linspace(0, steps - 1, NSTEP, dtype=int)
+    volt = cycle_voltage()
+    vinds = np.linspace(0, len(volt) - 1, NSTEP, dtype=int)
+
+    # geometry (inches)
+    tile, gut, blkgap, rgap = 0.46, 1.25, 0.34, 0.08
+    topv_h, v_gap, hdr_h = 1.0, 0.55, 0.34
+    stepnum_h, cbar_gap, cbar_h = 0.3, 0.32, 0.2
+    top_m, rmargin = 0.12, 0.35
+    block_w = NSTEP * tile
+    maps_w = 4 * block_w + 3 * blkgap
+    bands_h = nm * tile + (nm - 1) * rgap
+    fig_w = gut + maps_w + rmargin
+    fig_h = top_m + topv_h + v_gap + hdr_h + bands_h + stepnum_h + cbar_gap + cbar_h + 0.35
+
+    fig = plt.figure(figsize=(fig_w, fig_h))
+
+    def axbox(left, top, w, h):
+        return fig.add_axes([left / fig_w, (fig_h - top - h) / fig_h, w / fig_w, h / fig_h])
+
+    def block_left(p):
+        return gut + p * (block_w + blkgap)
+
+    # voltage plot (spans the maps width)
+    axv = axbox(gut, top_m, maps_w, topv_h)
+    axv.plot(volt, "k", lw=1.4)
+    for n, vi in enumerate(vinds):
+        axv.plot(vi, volt[vi], "o", color="k", ms=6)
+        axv.annotate(str(n + 1), (vi, volt[vi]), textcoords="offset points",
+                     xytext=(0, 5), ha="center", fontsize=8)
+    axv.set_ylabel("Voltage (V)"); axv.set_xlabel("Step"); axv.margins(x=0.01)
+
+    top_hdr = top_m + topv_h + v_gap
+    top_bands = top_hdr + hdr_h
+    # param column headers
+    for p in range(4):
+        fig.text((block_left(p) + block_w / 2) / fig_w,
+                 (fig_h - (top_hdr + hdr_h / 2)) / fig_h, NAMES[p],
+                 ha="center", va="center", fontsize=14)
+    # method row labels (once per band, horizontal, in the gutter)
+    for k in range(nm):
+        yc = top_bands + k * (tile + rgap) + tile / 2
+        fig.text((gut - 0.12) / fig_w, (fig_h - yc) / fig_h, labels[k],
+                 ha="right", va="center", fontsize=12)
+    # tiles
+    for k in range(nm):
+        top = top_bands + k * (tile + rgap)
+        for p in range(4):
+            for sidx, ind in enumerate(inds):
+                ax = axbox(block_left(p) + sidx * tile, top, tile * 0.94, tile * 0.94)
+                m2d = method_arrays[k][:, ind, p].reshape(SIDE, SIDE)
+                ax.imshow(m2d, cmap=SEQ_CMAP, vmin=CLIMS[p][0], vmax=CLIMS[p][1],
+                          aspect="auto", origin="lower")
+                ax.set_xticks([]); ax.set_yticks([])
+    # step numbers under bottom band
+    top_steps = top_bands + bands_h + 0.02
+    for p in range(4):
+        for sidx in range(NSTEP):
+            fig.text((block_left(p) + sidx * tile + tile / 2) / fig_w,
+                     (fig_h - (top_steps + stepnum_h / 2)) / fig_h, str(sidx + 1),
+                     ha="center", va="center", fontsize=8)
+    # one horizontal colorbar per parameter
+    top_cbar = top_bands + bands_h + stepnum_h + cbar_gap
+    for p in range(4):
+        cax = axbox(block_left(p) + block_w * 0.08, top_cbar, block_w * 0.84, cbar_h)
+        sm = ScalarMappable(norm=Normalize(*CLIMS[p]), cmap=SEQ_CMAP)
+        cb = fig.colorbar(sm, cax=cax, orientation="horizontal", format="%.2g")
+        cb.set_label(NAMES[p], fontsize=11); cax.tick_params(labelsize=8)
+
+    fig.savefig(f"./Figures/{filename}.png", dpi=300, bbox_inches="tight")
+    fig.savefig(f"./Figures/{filename}.svg", bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote ./Figures/{filename}.png and .svg  (fig {fig_w:.1f}x{fig_h:.1f} in)", flush=True)
+
+
+# ---- Figure_5_47: noise 7, LSQF + Adam + TR-CG (per-noise best) ----
+ma = load_model(7, "Adam"); mt = load_model(7, "Trust Region CG")
+p7 = get_params(7, [ma, mt])
+maps7 = [to_maps(p) for p in p7]
+plot_grid(maps7, ["LSQF", "Adam (network)", "TR-CG (network)"],
+          "Figure_5_47_switching_maps_comparison_7_noise")
+
+# ---- Figure_15: noise 0, single Adam model ----
+m0 = Multiscale1DFitter(SHO_fit_func_nn, dataset.frequency_bin, 2, 4,
+                        dataset.SHO_scaler, ComplexPostProcessor(dataset))
+mdl0 = Model(m0, dataset, training=False, model_basename="SHO_Fitter_original_data"); mdl0.load(ADAM0)
+st0 = {"resampled": True, "raw_format": "complex", "fitter": "LSQF", "scaled": False,
+       "output_shape": "index", "measurement_state": "all", "resampled_bins": 165,
+       "LSQF_phase_shift": np.pi / 2, "NN_phase_shift": None, "noise": 0}
+dataset.set_attributes(**st0)
+X0, _ = dataset.NN_data()
+nn0 = np.asarray(dataset.SHO_fit_results(model=mdl0, phase_shift=np.pi / 2, X_data=X0)).reshape(-1, 4)
+plot_grid([to_maps(nn0)], ["network (Adam)"], "Figure_15_NN_Switching_Maps")
+print("DONE switchmaps")

--- a/m3_learning/papers/2023_Rapid_Fitting/regenerate_violins.py
+++ b/m3_learning/papers/2023_Rapid_Fitting/regenerate_violins.py
@@ -38,6 +38,10 @@ def main():
     args = ap.parse_args()
 
     set_style("printing")
+    import sys as _s, os as _o
+    _s.path.insert(0,_o.path.dirname(_o.path.abspath(__file__)))
+    from pubstyle import set_pub_style, METHOD_COLORS, SEQ_CMAP
+    set_pub_style()
     random_seed(seed=42)
 
     printing = printer(basepath="./Figures/")

--- a/m3_learning/src/m3_learning/be/viz.py
+++ b/m3_learning/src/m3_learning/be/viz.py
@@ -1167,6 +1167,9 @@ class Viz:
         for step, (data, name) in enumerate(zip(data, names)):
             # unpack the data
             d1, d2, x1, x2, label, index1, mse1, params = data
+            # display frequency in MHz (ticks read 1.25/1.30/1.35, no 1e6 offset)
+            x1 = np.asarray(x1) / 1e6
+            x2 = np.asarray(x2) / 1e6
 
             # loops around the datasets to compare
             for bmw, (true, prediction, error, SHO, index1) in enumerate(
@@ -1254,33 +1257,15 @@ class Viz:
                             linestyle="--",
                             label=f"{color} {labels[1]}",
                         )
-                        if display_results == "all":
-                            error_string = f"MSE - LSQF: {errors['LSQF']:0.4f} NN: {errors['NN']:0.4f}\n AMP - LSQF:{SHOs['LSQF'][0]:0.2e} NN:{SHOs['NN'][0]:0.2e}\n\u03C9 - LSQF: {SHOs['LSQF'][1]/1000:0.1f} NN: {SHOs['NN'][1]/1000:0.1f} Hz\nQ- LSQF: {SHOs['LSQF'][2]:0.1f} NN: {SHOs['NN'][2]:0.1f}\n\u03C6- LSQF: {SHOs['LSQF'][3]:0.2f} NN: {SHOs['NN'][3]:0.1f} rad"
-                        elif display_results == "MSE":
-                            error_string = f"MSE - LSQF: {errors['LSQF']:0.4f} NN: {errors['NN']:0.4f}"
+                # sets the xlabel (frequency shown in MHz, see x1/x2 scaling above)
+                ax_.set_xlabel("Frequency (MHz)")
 
-                # sets the xlabel, this is always frequency (HZ)
-                ax_.set_xlabel("Frequency (Hz)")
-
-                # if wants to display the results
-                if display_results is not None:
-                    # gets the axis position in inches - gets the bottom center
-                    center = get_axis_pos_inches(fig, ax[i])
-
-                    # selects the text position as an offset from the bottom center
-                    text_position_in_inches = (center[0], center[1] - 0.33)
-
-                    if "error_string" not in locals():
-                        error_string = f"MSE: {error:0.4f}"
-
-                    add_text_to_figure(
-                        fig,
-                        error_string,
-                        text_position_in_inches,
-                        fontsize=6,
-                        ha="center",
-                        va="top",
-                    )
+                # reconstruction MSE goes in the panel TITLE (out of the data area,
+                # so it never overlaps the resonance peak)
+                if display_results is not None and {"LSQF", "NN"} <= set(errors):
+                    ax_.set_title(
+                        f"LSQF {errors['LSQF']:.4f}  |  NN {errors['NN']:.4f}",
+                        fontsize=9, pad=3)
 
                 if out_state is not None:
                     if "raw_format" in out_state.keys():
@@ -1303,7 +1288,7 @@ class Viz:
 
         # prints the figure
         if self.Printer is not None and filename is not None:
-            self.Printer.savefig(fig, filename, label_figs=ax, style="b")
+            self.Printer.savefig(fig, filename, label_figs=ax, style="b", loc="tr")
 
         return fig
 
@@ -2878,38 +2863,16 @@ class Viz:
                     (gaps[1] + size[1]) * (1.25 - i // 3 - 1.25) - gaps[1],
                 )
 
-                # gets the axis position in inches - gets the bottom center
-                center = get_axis_pos_inches(fig, ax[plot_idx])
-
-                # selects the text position as an offset from the bottom center
-                text_position_in_inches = (center[0], center[1] - 0.32 + .125)
-
-                error = results['MSE_LSQF']
-
-                error_string = f"LSQF MSE: {error:0.4f}"
-
-                add_text_to_figure(
-                    fig,
-                    error_string,
-                    text_position_in_inches,
-                    fontsize=6,
-                    ha="center",
-                )
-
-                # selects the text position as an offset from the bottom center
-                text_position_in_inches = (center[0], center[1] - 0.3)
-
-                error = results['MSE_NN']
-
-                error_string = f"NN MSE: {error:0.4f}"
-
-                add_text_to_figure(
-                    fig,
-                    error_string,
-                    text_position_in_inches,
-                    fontsize=6,
-                    ha="center",
-                )
+                # MSE shown INSIDE the panel (top-left) so it never overlaps the
+                # Voltage (V) axis label/ticks below the panel
+                error_string = (f"LSQF MSE {results['MSE_LSQF']:0.4f}\n"
+                                f"NN MSE {results['MSE_NN']:0.4f}")
+                # placed below the y-axis sci-offset (1e-4) so the two don't collide
+                ax[plot_idx].text(0.03, 0.82, error_string,
+                                  transform=ax[plot_idx].transAxes,
+                                  va="top", ha="left", fontsize=8.5,
+                                  bbox=dict(boxstyle="round,pad=0.2", fc="white",
+                                            ec="none", alpha=0.7))
 
                 ax[plot_idx - 1].set_ylabel("Amplitude (a.u.)")
                 ax[plot_idx].set_ylabel("Amplitude (a.u.)")
@@ -2928,6 +2891,6 @@ class Viz:
 
         # prints the figure
         if self.Printer is not None and filename is not None:
-            self.Printer.savefig(fig, filename, label_figs=ax, style="b")
+            self.Printer.savefig(fig, filename, label_figs=ax, style="b", loc="tr")
 
         return fig

--- a/m3_learning/src/m3_learning/be/viz.py
+++ b/m3_learning/src/m3_learning/be/viz.py
@@ -34,11 +34,14 @@ from dataclasses import dataclass, field
 from typing import List, Dict, Optional, Any, Type
 
 
+# One fixed color PER METHOD (matches pubstyle.METHOD_COLORS); amplitude vs phase
+# are distinguished by linestyle (solid vs dashed), not by a second color.
 color_palette = {
-    "LSQF_A": "#003f5c",
-    "LSQF_P": "#444e86",
-    "NN_A": "#955196",
-    "NN_P": "#dd5182",
+    "LSQF_A": "#0072B2",
+    "LSQF_P": "#0072B2",
+    "NN_A": "#E69F00",
+    "NN_P": "#E69F00",
+    "Raw": "#666666",
     "other": "#ff6e54",
     "other_2": "#ffa600",
 }
@@ -1188,21 +1191,25 @@ class Viz:
                     x2,
                     prediction[1].flatten(),
                     color=color_palette[f"{name}_P"],
+                    linestyle="--",
                     label=f"{name} {label[1]}",
                 )
+                ax_.set_ylabel("Amplitude (a.u.)")
+                ax1.set_ylabel("Phase (rad)")
 
                 ax_.plot(
                     x1,
                     true[0].flatten(),
                     "o",
-                    color=color_palette["LSQF_A"],
+                    color=color_palette["Raw"],
                     label=f"Raw {label[0]}",
                 )
                 ax1.plot(
                     x1,
                     true[1].flatten(),
                     "o",
-                    color=color_palette["LSQF_P"],
+                    markerfacecolor="none",
+                    color=color_palette["Raw"],
                     label=f"Raw {label[1]}",
                 )
 
@@ -1244,6 +1251,7 @@ class Viz:
                             x2,
                             pred_data.squeeze()[1].flatten(),
                             color=color_palette[f"{color}_P"],
+                            linestyle="--",
                             label=f"{color} {labels[1]}",
                         )
                         if display_results == "all":
@@ -1663,7 +1671,7 @@ class Viz:
                     ax[i * 4 + j + 1],
                     SHO_[:, ind, j],
                     colorbars=False,
-                    cmap="viridis",
+                    cmap="cividis",
                 )
 
                 if i // rows == 0:
@@ -1894,7 +1902,7 @@ class Viz:
                         ax[axis_start + j],
                         _SHO[:, ind, j],
                         colorbars=False,
-                        cmap="viridis",
+                        cmap="cividis",
                     )
 
                     if i // rows == 0 and k == 0:
@@ -2068,14 +2076,14 @@ class Viz:
             sns.violinplot(
                 data=df, x="parameter", y="value", hue="dataset", split=True,
                 inner="quart", cut=0, density_norm="width", linewidth=0.8,
-                palette={"LSQF": "#3B75AF", "NN": "#EF8636"}, ax=ax,
+                palette={"LSQF": "#0072B2", "NN": "#E69F00"}, ax=ax,
             )
         except TypeError:
             # older seaborn (<0.13) uses scale= instead of density_norm=
             sns.violinplot(
                 data=df, x="parameter", y="value", hue="dataset", split=True,
                 inner="quartile", cut=0, scale="width", linewidth=0.8,
-                palette={"LSQF": "#3B75AF", "NN": "#EF8636"}, ax=ax,
+                palette={"LSQF": "#0072B2", "NN": "#E69F00"}, ax=ax,
             )
 
         ax.set_ylabel("Scaled SHO parameter")
@@ -2129,13 +2137,13 @@ class Viz:
             sns.violinplot(
                 data=df, x="parameter", y="value", hue="dataset", split=True,
                 inner="quart", cut=0, density_norm="width", linewidth=0.7,
-                palette={"LSQF": "#3B75AF", "NN": "#EF8636"}, ax=ax,
+                palette={"LSQF": "#0072B2", "NN": "#E69F00"}, ax=ax,
             )
         except TypeError:
             sns.violinplot(
                 data=df, x="parameter", y="value", hue="dataset", split=True,
                 inner="quartile", cut=0, scale="width", linewidth=0.7,
-                palette={"LSQF": "#3B75AF", "NN": "#EF8636"}, ax=ax,
+                palette={"LSQF": "#0072B2", "NN": "#E69F00"}, ax=ax,
             )
 
         ax.set_ylabel("Scaled loop parameter")
@@ -2644,7 +2652,7 @@ class Viz:
             axs[0, i].imshow(
                 parms_pred[:, i].reshape(
                     embedding_image_size, embedding_image_size),
-                cmap="viridis",
+                cmap="cividis",
                 vmin=clims[i][0],
                 vmax=clims[i][1],
             )
@@ -2653,7 +2661,7 @@ class Viz:
             axs[1, i].imshow(
                 parms_lsqf[:, i].reshape(
                     embedding_image_size, embedding_image_size),
-                cmap="viridis",
+                cmap="cividis",
                 vmin=clims[i][0],
                 vmax=clims[i][1],
             )
@@ -2853,13 +2861,14 @@ class Viz:
                 index = int(results['Original Index'])
 
                 ax[plot_idx].plot(voltage,
-                                  raw_hysteresis_loop[index], 'o', label="Raw Data")
+                                  raw_hysteresis_loop[index], 'o',
+                                  color="#666666", label="Raw Data")
 
                 ax[plot_idx].plot(voltage,
-                                  loops[index], 'r', label='LSQF')
+                                  loops[index], color="#0072B2", label='LSQF')
 
                 ax[plot_idx].plot(voltage,
-                                  NN_loops[index], 'g', label='NN')
+                                  NN_loops[index], color="#E69F00", label='NN')
 
                 ax[plot_idx].ticklabel_format(style='sci', axis='y', scilimits=(0, 0))
 
@@ -2902,8 +2911,8 @@ class Viz:
                     ha="center",
                 )
 
-                ax[plot_idx - 1].set_ylabel("(Arb. U.)")
-                ax[plot_idx].set_ylabel("(Arb. U.)")
+                ax[plot_idx - 1].set_ylabel("Amplitude (a.u.)")
+                ax[plot_idx].set_ylabel("Amplitude (a.u.)")
 
         # ONE shared legend above the panel grid instead of putting a legend in
         # the last panels, where it overlapped the measured-loop points.


### PR DESCRIPTION
Improves the readability of the Rapid Fitting figures (builds on the pubstyle / violin / legend work in this branch).

## SHO fit-comparison panels (Figure_14, Figure_4c)
- Reconstruction MSE moved into each panel **title** (`LSQF 0.0216 | NN 0.0220`) instead of a text box over the resonance peak.
- Dropped the dense AMP/ω/Q/φ per-panel dump (MSE is the number that matters).
- Frequency axis shown in **MHz** (display-only rescale; data unchanged).
- Larger, wider panels with a small inter-row gap so the 6 panels fill the figure.
- Method colors fixed (LSQF blue, NN orange), amplitude solid / phase dashed, raw data gray; single shared legend.

## hysteresis_comparison
- Per-panel MSE moved inside each panel, clear of the Voltage (V) axis; LSQF blue / NN orange / Raw gray.

## Switching-map grids (Figure_5_47, Figure_15) — `regen_switchmaps.py`
Rebuilt from scratch with explicit geometry to remove all the overlap in the baked-in layout, keeping all content (9 steps × 4 params × N methods):
- one horizontal method label per row band (no more stacked/garbled labels),
- A/ω₀/Q/φ column headers + a 1–9 step row,
- four separated per-parameter colorbars,
- the voltage-step plot spaced above the map grid,
- cividis, square tiles, generous gaps, landscape SI canvas.

Figures themselves (PNG/SVG) are gitignored; this PR is the code that regenerates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Standardize Rapid Fitting visualization styling and add scripts to regenerate and analyze key paper figures with improved layouts and metrics.

New Features:
- Add analysis and plotting scripts under 2023_Rapid_Fitting to regenerate core SHO, switching-map, noise-robustness, and hysteresis figures directly from checkpoints and cached fits.
- Introduce utilities to compute and summarize parameter agreement, reconstruction MSE distributions, out-of-range parameter fractions, and overfitting diagnostics across noise levels.

Enhancements:
- Unify LSQF/NN color schemes and raw-data styling across SHO fit, hysteresis, violin, and switching-map visualizations, including consistent cividis/sequence colormaps and top-right legends.
- Improve SHO fit-comparison and hysteresis panels by moving MSE summaries into panel titles or in-panel boxes, using MHz frequency axes, and clarifying amplitude/phase labeling.
- Wire Rapid Fitting figure-regeneration scripts to the shared pub-style configuration so regenerated figures match publication styling.