### PR TITLE
Don't fail a notebook when provenance teardown can't reach the server

### DIFF
--- a/Testing/fast_force_mapping.ipynb
+++ b/Testing/fast_force_mapping.ipynb
@@ -192,7 +192,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/2_Pytorch_SHO_Fitter_TEST.ipynb
+++ b/m3_learning/2_Pytorch_SHO_Fitter_TEST.ipynb
@@ -1959,7 +1959,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/Datasets/Mixed_phase_pzt_BEPFM/1_SHO_Fitting.ipynb
+++ b/m3_learning/Datasets/Mixed_phase_pzt_BEPFM/1_SHO_Fitting.ipynb
@@ -657,7 +657,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/Tutorials/Cycle_Consistent_Spatial_Transformer_Autoencoder/Cycle_Consistent_Spatial_Transformer_Autoencoder.ipynb
+++ b/m3_learning/Tutorials/Cycle_Consistent_Spatial_Transformer_Autoencoder/Cycle_Consistent_Spatial_Transformer_Autoencoder.ipynb
@@ -1843,7 +1843,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/Tutorials/Physics_Informed_Autoencoders/Physics_Constrained_Autoencoder.ipynb
+++ b/m3_learning/Tutorials/Physics_Informed_Autoencoders/Physics_Constrained_Autoencoder.ipynb
@@ -9839,7 +9839,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/Tutorials/Unsupervised_Learning_with_AEs/Unsupervised_Learning_with_Autoencoders.ipynb
+++ b/m3_learning/Tutorials/Unsupervised_Learning_with_AEs/Unsupervised_Learning_with_Autoencoders.ipynb
@@ -47976,7 +47976,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_Imaging_ferroelectric_domains_by_scanning_electron_diffraction/STEM_Domains.ipynb
+++ b/m3_learning/papers/2023_Imaging_ferroelectric_domains_by_scanning_electron_diffraction/STEM_Domains.ipynb
@@ -10104,7 +10104,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_Imaging_ferroelectric_domains_by_scanning_electron_diffraction/STEM_vortex_VAE.ipynb
+++ b/m3_learning/papers/2023_Imaging_ferroelectric_domains_by_scanning_electron_diffraction/STEM_vortex_VAE.ipynb
@@ -1198,7 +1198,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_RHEED_PLD_SrTiO3/1_Abstract.ipynb
+++ b/m3_learning/papers/2023_RHEED_PLD_SrTiO3/1_Abstract.ipynb
@@ -171,7 +171,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_RHEED_PLD_SrTiO3/2_RHEED_metrics.ipynb
+++ b/m3_learning/papers/2023_RHEED_PLD_SrTiO3/2_RHEED_metrics.ipynb
@@ -570,7 +570,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_RHEED_PLD_SrTiO3/3_RHEED_metrics-details.ipynb
+++ b/m3_learning/papers/2023_RHEED_PLD_SrTiO3/3_RHEED_metrics-details.ipynb
@@ -3059,7 +3059,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_RHEED_PLD_SrTiO3/4_AFM_and_XRD.ipynb
+++ b/m3_learning/papers/2023_RHEED_PLD_SrTiO3/4_AFM_and_XRD.ipynb
@@ -433,7 +433,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_RHEED_PLD_SrTiO3/5_AFM_and_XRD-details.ipynb
+++ b/m3_learning/papers/2023_RHEED_PLD_SrTiO3/5_AFM_and_XRD-details.ipynb
@@ -9360,7 +9360,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_RHEED_PLD_SrTiO3/6_Growth_mechanism.ipynb
+++ b/m3_learning/papers/2023_RHEED_PLD_SrTiO3/6_Growth_mechanism.ipynb
@@ -239,7 +239,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_RHEED_PLD_SrTiO3/7_Growth_mechanism-details.ipynb
+++ b/m3_learning/papers/2023_RHEED_PLD_SrTiO3/7_Growth_mechanism-details.ipynb
@@ -2874,7 +2874,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_RHEED_PLD_SrTiO3/8_Characteristic_time.ipynb
+++ b/m3_learning/papers/2023_RHEED_PLD_SrTiO3/8_Characteristic_time.ipynb
@@ -195,7 +195,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_RHEED_PLD_SrTiO3/9_Characteristic_time-details.ipynb
+++ b/m3_learning/papers/2023_RHEED_PLD_SrTiO3/9_Characteristic_time-details.ipynb
@@ -1665,7 +1665,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_Rapid_Fitting/0_5_Noisy_Data_and_Fitting.ipynb
+++ b/m3_learning/papers/2023_Rapid_Fitting/0_5_Noisy_Data_and_Fitting.ipynb
@@ -368,7 +368,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_Rapid_Fitting/0_Introduction.ipynb
+++ b/m3_learning/papers/2023_Rapid_Fitting/0_Introduction.ipynb
@@ -209,7 +209,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_Rapid_Fitting/1_SHO_Fitting.ipynb
+++ b/m3_learning/papers/2023_Rapid_Fitting/1_SHO_Fitting.ipynb
@@ -501,7 +501,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_Rapid_Fitting/2_5_nn_fitting_all.ipynb
+++ b/m3_learning/papers/2023_Rapid_Fitting/2_5_nn_fitting_all.ipynb
@@ -376,7 +376,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_Rapid_Fitting/2_Pytorch_SHO_Fitter.ipynb
+++ b/m3_learning/papers/2023_Rapid_Fitting/2_Pytorch_SHO_Fitter.ipynb
@@ -991,7 +991,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_Rapid_Fitting/3_Second_Order_Optimizers.ipynb
+++ b/m3_learning/papers/2023_Rapid_Fitting/3_Second_Order_Optimizers.ipynb
@@ -587,7 +587,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_Rapid_Fitting/4_5_benchmark_analysis.ipynb
+++ b/m3_learning/papers/2023_Rapid_Fitting/4_5_benchmark_analysis.ipynb
@@ -824,7 +824,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_Rapid_Fitting/4_Noisy_Data_Analysis.ipynb
+++ b/m3_learning/papers/2023_Rapid_Fitting/4_Noisy_Data_Analysis.ipynb
@@ -3192,7 +3192,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_Rapid_Fitting/5_Hysteresis_Fitter.ipynb
+++ b/m3_learning/papers/2023_Rapid_Fitting/5_Hysteresis_Fitter.ipynb
@@ -670,7 +670,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_Rapid_Fitting/6_Figures.ipynb
+++ b/m3_learning/papers/2023_Rapid_Fitting/6_Figures.ipynb
@@ -1179,7 +1179,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_the_effect_of_chemical_environment_and_temperature_on_the_domain_structure_of_freestanding_BaTiO3_via_in_situ_STEM/BTO_environmental_demo copy.ipynb
+++ b/m3_learning/papers/2023_the_effect_of_chemical_environment_and_temperature_on_the_domain_structure_of_freestanding_BaTiO3_via_in_situ_STEM/BTO_environmental_demo copy.ipynb
@@ -794,7 +794,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/2023_the_effect_of_chemical_environment_and_temperature_on_the_domain_structure_of_freestanding_BaTiO3_via_in_situ_STEM/BTO_environmental_demo.ipynb
+++ b/m3_learning/papers/2023_the_effect_of_chemical_environment_and_temperature_on_the_domain_structure_of_freestanding_BaTiO3_via_in_situ_STEM/BTO_environmental_demo.ipynb
@@ -966,7 +966,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/papers/layernorm.ipynb
+++ b/m3_learning/papers/layernorm.ipynb
@@ -260,7 +260,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/src/m3_learning/artifacts.py
+++ b/m3_learning/src/m3_learning/artifacts.py
@@ -243,8 +243,7 @@ class DataeraiArtifactPublisher:
                 try:
                     return original(*args, **kwargs)
                 except Exception as exc:  # noqa: BLE001 - SDK/network boundary
-                    code = str(getattr(exc, "code", ""))
-                    if "EXISTS" in code.upper() or "EXISTS" in str(exc).upper():
+                    if _is_relationship_exists_error(exc):
                         # Already in the desired state - _relationship() treats this
                         # as success, so the wrapper must not diverge and re-raise.
                         return None
@@ -1228,8 +1227,7 @@ class DataeraiArtifactPublisher:
                 )
                 return
             except Exception as exc:
-                code = str(getattr(exc, "code", ""))
-                if "EXISTS" in code.upper() or "EXISTS" in str(exc).upper():
+                if _is_relationship_exists_error(exc):
                     return
                 if attempt == attempts or not _is_transient_upload_error(exc):
                     raise
@@ -1467,6 +1465,18 @@ def _env_bool(name: str, *, default: bool) -> bool:
     return value.strip().lower() not in {"", "0", "false", "no", "off"}
 
 
+def _is_relationship_exists_error(exc: Exception) -> bool:
+    """Return whether an exception means the relationship already exists.
+
+    Matches the SDK's specific error code rather than substring-testing arbitrary
+    exception text, which would swallow unrelated failures that merely mention
+    EXISTS.
+    """
+
+    code = str(getattr(exc, "code", "")).upper()
+    return "ERR_RELATIONSHIP_EXISTS" in code or "ERR_RELATIONSHIP_EXISTS" in str(exc).upper()
+
+
 def _is_withdrawn_trace_error(message: str) -> bool:
     """Return whether an artifact error is just "the trace is already gone"."""
 
@@ -1508,7 +1518,12 @@ def _max_retry_backoff_seconds() -> float:
     which could not outlast a 22s beta outage observed on 2026-08-30.
     """
 
-    return float(os.environ.get("DATAERAI_MAX_RETRY_BACKOFF_S", "30"))
+    try:
+        seconds = float(os.environ.get("DATAERAI_MAX_RETRY_BACKOFF_S", "30"))
+    except ValueError:
+        return 30.0
+    # A negative cap would reach time.sleep() and raise instead of retrying.
+    return max(0.0, seconds)
 
 
 def _max_inline_asset_bytes() -> int:

--- a/m3_learning/src/m3_learning/artifacts.py
+++ b/m3_learning/src/m3_learning/artifacts.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import os
 import time
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -220,7 +221,7 @@ class DataeraiArtifactPublisher:
                 except Exception as exc:  # noqa: BLE001 - SDK/network boundary
                     if attempt == attempts or not _is_transient_upload_error(exc):
                         raise
-                    time.sleep(min(2 ** (attempt - 1), 8))
+                    time.sleep(min(2 ** (attempt - 1), _max_retry_backoff_seconds()))
             raise AssertionError("unreachable")
 
         retrying_upload._m3_retrying_upload = True  # type: ignore[attr-defined]
@@ -244,10 +245,12 @@ class DataeraiArtifactPublisher:
                 except Exception as exc:  # noqa: BLE001 - SDK/network boundary
                     code = str(getattr(exc, "code", ""))
                     if "EXISTS" in code.upper() or "EXISTS" in str(exc).upper():
-                        raise
+                        # Already in the desired state - _relationship() treats this
+                        # as success, so the wrapper must not diverge and re-raise.
+                        return None
                     if attempt == attempts or not _is_transient_upload_error(exc):
                         raise
-                    time.sleep(min(2 ** (attempt - 1), 8))
+                    time.sleep(min(2 ** (attempt - 1), _max_retry_backoff_seconds()))
             raise AssertionError("unreachable")
 
         retrying_relationship._m3_retrying_relationship = True  # type: ignore[attr-defined]
@@ -264,7 +267,7 @@ class DataeraiArtifactPublisher:
             except Exception as exc:  # noqa: BLE001 - SDK/network boundary
                 if attempt == attempts or not _is_transient_upload_error(exc):
                     raise
-                time.sleep(min(2 ** (attempt - 1), 8))
+                time.sleep(min(2 ** (attempt - 1), _max_retry_backoff_seconds()))
         raise AssertionError("unreachable")
 
     def _publish_source_notebook(self) -> None:
@@ -607,6 +610,20 @@ class DataeraiArtifactPublisher:
             f"{_counted(len(self._model_asset_ids), 'model artifact')}."
         )
         if self._errors and self.strict:
+            # A trace withdrawn mid-run by a transient server fault is not an
+            # artifact-publishing defect: the notebook computed correctly and its
+            # outputs are already on disk. Failing here discards that work (we
+            # lost a 2h09m run this way), so warn and let the notebook exit 0.
+            if all(_is_withdrawn_trace_error(err) for err in self._errors):
+                warnings.warn(
+                    "Dataerai artifact publishing skipped: the notebook trace was "
+                    "withdrawn before artifacts could be published "
+                    f"({len(self._errors)} artifact(s) affected). Computed outputs "
+                    "are unaffected.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                return self._result
             raise RuntimeError(
                 "Dataerai artifact publishing failed: " + "; ".join(self._errors)
             )
@@ -1103,7 +1120,7 @@ class DataeraiArtifactPublisher:
             except Exception as exc:  # noqa: BLE001 - SDK/network boundary
                 if attempt == attempts or not _is_transient_upload_error(exc):
                     raise
-                time.sleep(min(2 ** (attempt - 1), 8))
+                time.sleep(min(2 ** (attempt - 1), _max_retry_backoff_seconds()))
         raise AssertionError("unreachable")
 
     def _upload_once(
@@ -1216,7 +1233,7 @@ class DataeraiArtifactPublisher:
                     return
                 if attempt == attempts or not _is_transient_upload_error(exc):
                     raise
-                time.sleep(min(2 ** (attempt - 1), 8))
+                time.sleep(min(2 ** (attempt - 1), _max_retry_backoff_seconds()))
 
     def _attempt(self, operation: Any) -> None:
         try:
@@ -1450,6 +1467,12 @@ def _env_bool(name: str, *, default: bool) -> bool:
     return value.strip().lower() not in {"", "0", "false", "no", "off"}
 
 
+def _is_withdrawn_trace_error(message: str) -> bool:
+    """Return whether an artifact error is just "the trace is already gone"."""
+
+    return "requires an active notebook trace" in str(message).casefold()
+
+
 def _is_transient_upload_error(exc: Exception) -> bool:
     """Return whether retrying an SDK upload can reasonably succeed."""
 
@@ -1476,6 +1499,16 @@ def _is_transient_upload_error(exc: Exception) -> bool:
             'server status "failed"',
         )
     )
+
+
+def _max_retry_backoff_seconds() -> float:
+    """Cap for exponential retry backoff.
+
+    The previous hard-coded 8s cap gave ~23s of total sleep across 5 attempts,
+    which could not outlast a 22s beta outage observed on 2026-08-30.
+    """
+
+    return float(os.environ.get("DATAERAI_MAX_RETRY_BACKOFF_S", "30"))
 
 
 def _max_inline_asset_bytes() -> int:

--- a/m3_learning/src/m3_learning/tests/test.ipynb
+++ b/m3_learning/src/m3_learning/tests/test.ipynb
@@ -824,7 +824,16 @@
    },
    "source": [
     "dataerai_artifact_result = dataerai_artifacts.finish()\n",
-    "%dataerai --finish\n"
+    "# A transient server fault can withdraw the trace mid-run. `--finish`\n",
+    "# raises in that case, which would fail a notebook that already computed\n",
+    "# its results correctly, so only finish a trace that is still active.\n",
+    "if getattr(dataerai_session, \"_trace\", None) is not None:\n",
+    "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n",
+    "else:\n",
+    "    print(\n",
+    "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n",
+    "        \"skipping --finish. Computed outputs are unaffected.\"\n",
+    "    )\n"
    ],
    "execution_count": null,
    "outputs": []

--- a/m3_learning/tests/test_notebook_provenance.py
+++ b/m3_learning/tests/test_notebook_provenance.py
@@ -15,6 +15,9 @@ IGNORED_NOTEBOOK_DIRECTORIES = {
     "_build",
     "executed",
 }
+# nbconvert writes its output beside the source notebook, so exclude those by
+# name too - otherwise this test fails for anyone who has executed a notebook.
+IGNORED_NOTEBOOK_PREFIXES = ("executed_", "output_")
 
 
 def _source_notebooks():
@@ -24,6 +27,7 @@ def _source_notebooks():
         path
         for path in notebooks
         if not IGNORED_NOTEBOOK_DIRECTORIES.intersection(path.parts)
+        and not path.name.startswith(IGNORED_NOTEBOOK_PREFIXES)
     )
 
 
@@ -58,7 +62,11 @@ def test_every_source_notebook_has_one_managed_provenance_boundary():
         finish = cells[finish_index]
         finish_source = "".join(finish["source"])
         assert "dataerai_artifacts.finish()" in finish_source
-        assert finish_source.strip().endswith("%dataerai --finish")
+        # the trace is finished only when it is still active: a transient server
+        # fault can withdraw it mid-run, and finishing then raises and fails a
+        # notebook that already computed its results correctly.
+        assert 'run_line_magic("dataerai", "--finish")' in finish_source
+        assert 'getattr(dataerai_session, "_trace", None) is not None' in finish_source
         assert not any(
             cell.get("cell_type") == "code" for cell in cells[finish_index + 1 :]
         ), f"{path}: code appears after the trace is finished"

--- a/tools/update_dataerai_notebook_provenance.py
+++ b/tools/update_dataerai_notebook_provenance.py
@@ -29,6 +29,9 @@ IGNORED_NOTEBOOK_DIRECTORIES = {
 }
 
 
+IGNORED_NOTEBOOK_PREFIXES = ("executed_", "output_")
+
+
 def source_notebooks() -> list[Path]:
     """Return authored notebooks, excluding generated Jupyter Book output."""
 
@@ -38,7 +41,20 @@ def source_notebooks() -> list[Path]:
         path
         for path in notebooks
         if not IGNORED_NOTEBOOK_DIRECTORIES.intersection(path.parts)
+        and not _is_execution_output(path)
     )
+
+
+def _is_execution_output(path: Path) -> bool:
+    """Return whether a notebook is nbconvert output rather than an authored source.
+
+    ``jupyter nbconvert --execute`` writes its result beside the source notebook,
+    so without this an execution record gets treated as an authored notebook and
+    its managed cells are rewritten - silently editing the source of a run that
+    already happened.
+    """
+
+    return path.name.startswith(IGNORED_NOTEBOOK_PREFIXES)
 
 
 def _source_lines(text: str) -> list[str]:
@@ -325,7 +341,16 @@ def _managed_cells(path: Path, notebook: dict) -> tuple[list[dict], list[dict]]:
         "code",
         "dataerai-provenance-finish",
         "dataerai_artifact_result = dataerai_artifacts.finish()\n"
-        "%dataerai --finish\n",
+        "# A transient server fault can withdraw the trace mid-run. `--finish`\n"
+        "# raises in that case, which would fail a notebook that already computed\n"
+        "# its results correctly, so only finish a trace that is still active.\n"
+        "if getattr(dataerai_session, \"_trace\", None) is not None:\n"
+        "    get_ipython().run_line_magic(\"dataerai\", \"--finish\")\n"
+        "else:\n"
+        "    print(\n"
+        "        \"Dataerai notebook trace was withdrawn before the finish cell; \"\n"
+        "        \"skipping --finish. Computed outputs are unaffected.\"\n"
+        "    )\n",
     )
     for cell in (intro, start, finish_note, finish):
         cell["metadata"]["dataerai"] = {


### PR DESCRIPTION
Running the full 9-notebook 2023_Rapid_Fitting reproduction against beta.dataerai.com surfaced four issues. All of them cost completed science, not provenance.

1. A withdrawn trace fails the notebook.

   A transient server fault withdraws the notebook trace mid-run. Every queued artifact then raises "artifact publishing requires an active notebook trace" (46 repetitions in one traceback), and with DATAERAI_ARTIFACT_STRICT defaulting to True, finish() re-raises them. The final cell's unguarded `%dataerai --finish` raises for the same reason.

   This discarded a 2h09m 4_Noisy_Data_Analysis run that had already written all of its figures, and caused exit 1 for 1_SHO_Fitting and 2_Pytorch_SHO_Fitter. A provenance teardown step should never fail a notebook that computed correctly.

   finish() now warns and returns when every error is a withdrawn trace, and the generated finish cell only calls --finish while the trace is still active.

2. Retry backoff could not outlast a real outage.

   The 8s cap gave ~23s of total sleep across 5 attempts. On 2026-08-30 beta returned 503s at 02:29:49/50/52 and 02:30:03 then 502s at 02:30:05/11 - a 22s window that exhausted the retries from inside. The cap is now DATAERAI_MAX_RETRY_BACKOFF_S, default 30s.

3. The generator rewrote nbconvert output notebooks.

   source_notebooks() filtered by directory but never by filename, so `executed_*.ipynb` written beside a source notebook (nbconvert's default) was treated as authored and had its managed cells rewritten, silently editing the record of a run that already happened.

4. test_every_source_notebook_has_one_managed_provenance_boundary failed on a clean checkout for anyone who had executed a notebook: it hardcodes `len(notebooks) == 31` and counted 56 with executed_* present. It now applies the same prefix filter.

Also makes the create_relationship wrapper treat ERR_RELATIONSHIP_EXISTS as success, matching _relationship() - the desired state already holds. 752 of these were logged across the run.

The 31 notebook changes are all regenerated by the tool and contain only the guarded finish cell.

## Summary by Sourcery

Make provenance handling resilient to withdrawn notebook traces and transient service outages without discarding completed notebook computations.

Bug Fixes:
- Prevent notebook execution from failing when a transient server fault withdraws the notebook trace before provenance teardown.
- Treat existing relationships as successful and improve retry behavior during extended service outages.
- Exclude generated execution-output notebooks from provenance generation and validation.

Enhancements:
- Make withdrawn-trace artifact publishing emit a warning and preserve successfully computed notebook outputs instead of raising.
- Allow retry backoff to be configured through DATAERAI_MAX_RETRY_BACKOFF_S, defaulting to 30 seconds.
- Regenerate managed notebook finish cells to skip teardown when the trace is no longer active.

Tests:
- Update notebook provenance validation to ignore executed and output notebooks and require guarded finish cells.