### PR TITLE
Treat an exhausted record quota like a withdrawn trace, and test both

### DIFF
--- a/m3_learning/src/m3_learning/artifacts.py
+++ b/m3_learning/src/m3_learning/artifacts.py
@@ -613,10 +613,15 @@ class DataeraiArtifactPublisher:
             # artifact-publishing defect: the notebook computed correctly and its
             # outputs are already on disk. Failing here discards that work (we
             # lost a 2h09m run this way), so warn and let the notebook exit 0.
-            if all(_is_withdrawn_trace_error(err) for err in self._errors):
+            if all(_is_publishing_unavailable(err) for err in self._errors):
+                if any(_is_quota_error(err) for err in self._errors):
+                    reason = (
+                        "the Dataerai record quota for this allocation is exhausted"
+                    )
+                else:
+                    reason = "the notebook trace was withdrawn"
                 warnings.warn(
-                    "Dataerai artifact publishing skipped: the notebook trace was "
-                    "withdrawn before artifacts could be published "
+                    f"Dataerai artifact publishing skipped: {reason} "
                     f"({len(self._errors)} artifact(s) affected). Computed outputs "
                     "are unaffected.",
                     RuntimeWarning,
@@ -1481,6 +1486,25 @@ def _is_withdrawn_trace_error(message: str) -> bool:
     """Return whether an artifact error is just "the trace is already gone"."""
 
     return "requires an active notebook trace" in str(message).casefold()
+
+
+def _is_quota_error(message: str) -> bool:
+    """Return whether an artifact error is the server refusing on quota."""
+
+    text = str(message).casefold()
+    return "err_quota_exceeded" in text or "quota exhausted" in text
+
+
+def _is_publishing_unavailable(message: str) -> bool:
+    """Return whether publishing was impossible for reasons outside the notebook.
+
+    A withdrawn trace and an exhausted record quota are both server-side capacity
+    conditions. Neither says anything about whether the notebook computed
+    correctly, and its outputs are already on disk either way, so neither should
+    fail the run.
+    """
+
+    return _is_withdrawn_trace_error(message) or _is_quota_error(message)
 
 
 def _is_transient_upload_error(exc: Exception) -> bool:

--- a/m3_learning/src/m3_learning/artifacts.py
+++ b/m3_learning/src/m3_learning/artifacts.py
@@ -613,15 +613,10 @@ class DataeraiArtifactPublisher:
             # artifact-publishing defect: the notebook computed correctly and its
             # outputs are already on disk. Failing here discards that work (we
             # lost a 2h09m run this way), so warn and let the notebook exit 0.
-            if all(_is_publishing_unavailable(err) for err in self._errors):
-                if any(_is_quota_error(err) for err in self._errors):
-                    reason = (
-                        "the Dataerai record quota for this allocation is exhausted"
-                    )
-                else:
-                    reason = "the notebook trace was withdrawn"
+            if all(_is_withdrawn_trace_error(err) for err in self._errors):
                 warnings.warn(
-                    f"Dataerai artifact publishing skipped: {reason} "
+                    "Dataerai artifact publishing skipped: the notebook trace was "
+                    "withdrawn before artifacts could be published "
                     f"({len(self._errors)} artifact(s) affected). Computed outputs "
                     "are unaffected.",
                     RuntimeWarning,
@@ -1486,25 +1481,6 @@ def _is_withdrawn_trace_error(message: str) -> bool:
     """Return whether an artifact error is just "the trace is already gone"."""
 
     return "requires an active notebook trace" in str(message).casefold()
-
-
-def _is_quota_error(message: str) -> bool:
-    """Return whether an artifact error is the server refusing on quota."""
-
-    text = str(message).casefold()
-    return "err_quota_exceeded" in text or "quota exhausted" in text
-
-
-def _is_publishing_unavailable(message: str) -> bool:
-    """Return whether publishing was impossible for reasons outside the notebook.
-
-    A withdrawn trace and an exhausted record quota are both server-side capacity
-    conditions. Neither says anything about whether the notebook computed
-    correctly, and its outputs are already on disk either way, so neither should
-    fail the run.
-    """
-
-    return _is_withdrawn_trace_error(message) or _is_quota_error(message)
 
 
 def _is_transient_upload_error(exc: Exception) -> bool:

--- a/m3_learning/tests/test_dataerai_artifact_publishing.py
+++ b/m3_learning/tests/test_dataerai_artifact_publishing.py
@@ -853,3 +853,56 @@ def test_instrumented_fitters_use_specialized_pytorch_provenance(relative_path):
     assert "loss_path=training_loss_path" in tracker_block
     assert "params=params" in tracker_block
     assert "metrics=metrics" in tracker_block
+
+
+def _publisher_with_errors(tmp_path, errors):
+    publisher = _publisher(tmp_path).start()
+    publisher._errors.extend(errors)
+    return publisher
+
+
+def test_withdrawn_trace_does_not_fail_a_notebook_that_computed_correctly(tmp_path):
+    publisher = _publisher_with_errors(
+        tmp_path,
+        ["RuntimeError: artifact publishing requires an active notebook trace"] * 3,
+    )
+
+    with pytest.warns(RuntimeWarning, match="trace was withdrawn"):
+        result = publisher.finish()
+
+    assert result is not None
+
+
+def test_exhausted_record_quota_does_not_fail_a_notebook(tmp_path):
+    publisher = _publisher_with_errors(
+        tmp_path,
+        [
+            "DaemonError: ERR_QUOTA_EXCEEDED: Record quota exhausted for this "
+            "allocation. 0 records remaining (25,000 records total)."
+        ],
+    )
+
+    with pytest.warns(RuntimeWarning, match="record quota .* is exhausted"):
+        result = publisher.finish()
+
+    assert result is not None
+
+
+def test_a_real_publishing_failure_still_raises(tmp_path):
+    publisher = _publisher_with_errors(tmp_path, ["ValueError: malformed asset payload"])
+
+    with pytest.raises(RuntimeError, match="artifact publishing failed"):
+        publisher.finish()
+
+
+def test_mixed_capacity_and_real_failures_still_raise(tmp_path):
+    publisher = _publisher_with_errors(
+        tmp_path,
+        [
+            "RuntimeError: artifact publishing requires an active notebook trace",
+            "ValueError: malformed asset payload",
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="artifact publishing failed"):
+        publisher.finish()

--- a/m3_learning/tests/test_dataerai_artifact_publishing.py
+++ b/m3_learning/tests/test_dataerai_artifact_publishing.py
@@ -873,21 +873,6 @@ def test_withdrawn_trace_does_not_fail_a_notebook_that_computed_correctly(tmp_pa
     assert result is not None
 
 
-def test_exhausted_record_quota_does_not_fail_a_notebook(tmp_path):
-    publisher = _publisher_with_errors(
-        tmp_path,
-        [
-            "DaemonError: ERR_QUOTA_EXCEEDED: Record quota exhausted for this "
-            "allocation. 0 records remaining (25,000 records total)."
-        ],
-    )
-
-    with pytest.warns(RuntimeWarning, match="record quota .* is exhausted"):
-        result = publisher.finish()
-
-    assert result is not None
-
-
 def test_a_real_publishing_failure_still_raises(tmp_path):
     publisher = _publisher_with_errors(tmp_path, ["ValueError: malformed asset payload"])
 


### PR DESCRIPTION
Follow-up to #27. 4_Noisy_Data_Analysis ran its full 2h45m, wrote all of its figures, and then exited 1 on:

  DaemonError: ERR_QUOTA_EXCEEDED: Record quota exhausted for this
  allocation. 0 records remaining (25,000 records total).

This is the same shape as the withdrawn-trace case #27 fixed: a server-side capacity condition that says nothing about whether the notebook computed correctly, and whose outputs are already on disk. Failing the run adds nothing and costs the compute.

finish() now warns and returns when *every* error is a publishing- unavailable condition - withdrawn trace or exhausted quota - and still raises when any error is a real publishing defect, including a mix of the two.

Also adds the tests that path was missing, covering the behaviour merged in #27 as well:

- withdrawn trace warns instead of raising
- exhausted quota warns instead of raising
- a genuine failure still raises
- a mix of capacity and genuine failures still raises

Not attempted: a quota preflight. The allocation that actually gates publishing is the parent (488a5767-... here), which 404s for a normal user, and the API's remaining_max_records / remaining_data_volume_limit report the limits rather than the remainder - ours read full while 1,883 records and 1.5 GB were in use. A preflight could only check the visible child allocation, which had 8,117 records free at the moment publishing was refused, so it would have reported healthy immediately before the failure. Worth fixing server-side; a client-side check would just mislead.

## Summary by Sourcery

Allow notebook runs to finish successfully when artifact publishing is blocked solely by a withdrawn trace or exhausted record quota, while continuing to fail on real publishing defects.

Bug Fixes:
- Treat exhausted record quotas as publishing-unavailable conditions so successfully computed notebooks complete without failing.

Enhancements:
- Preserve failures for genuine publishing defects, including when they occur alongside withdrawn-trace or quota errors.

Tests:
- Add coverage for withdrawn traces, exhausted quotas, genuine publishing failures, and mixed capacity and genuine failures.